### PR TITLE
Fix for incorrect normal direction calculation for overlay textures

### DIFF
--- a/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
@@ -635,31 +635,9 @@ float3x3 AngleAxis3x3(float angle, float3 axis)
 
 float3 GetRotatedTangent(uint orient, float3 axis, float3 tangent)
 {
-	switch (orient)
-	{
-	case 1:
-	{
-		float3x3 rotator = AngleAxis3x3(1.570796 * 3.0,axis);
-		return mul(rotator, tangent);
-	} break;
-
-	case 2:
-	{
-		float3x3 rotator = AngleAxis3x3(1.570796 * 2.0,axis);
-		return mul(rotator, tangent);
-	} break;
-
-	case 3:
-	{
-		float3x3 rotator = AngleAxis3x3(1.570796,axis);
-		return mul(rotator, tangent);
-	} break;
-
-	default:
-	{
-		return tangent;
-	} break;
-	}
+	float3x3 rotator = AngleAxis3x3(orient * -1.570796,axis);
+	return mul(rotator, tangent);
+	
 }
 
 float2 GetRotatedUVs(uint orient, float2 uv)
@@ -730,7 +708,6 @@ void GetHitMaterialAndUVs(InstanceData instance_data, RT_Triangle hit_triangle, 
 	};
 
 	tangent = GetHitAttribute(tangents, barycentrics);
-	float3 tangent_rotated = GetRotatedTangent(orient, normal, tangent);
 	
 	// TODO(daniel): Clean this messy silly code up!
 	if (material_index2 != 0xFFFFFFFF)
@@ -742,8 +719,11 @@ void GetHitMaterialAndUVs(InstanceData instance_data, RT_Triangle hit_triangle, 
 		if (albedo2.a > 0.0)
 		{
 			material_index = material_index2;
-			uv = uv_rotated;
-			tangent = tangent_rotated;
+			if(orient != 0)
+			{
+				uv = uv_rotated;
+				tangent = GetRotatedTangent(orient, normal, tangent);
+			}
 		}
 	}
 }

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
@@ -57,7 +57,9 @@ void GetGeometryDataFromPrimaryRay(RayDesc ray_desc, PrimaryRayPayload ray_paylo
         // Set up hit material
 
         float2 uv = (float2)0;
-        GetHitMaterialAndUVs(OUT.instance_data, OUT.hit_triangle, ray_payload.barycentrics, OUT.material_index, uv);
+		float3 interpolated_normal = (float3)0;
+		float3 tangent = (float3)0;
+        GetHitMaterialAndUVs(OUT.instance_data, OUT.hit_triangle, ray_payload.barycentrics, OUT.material_index, uv, interpolated_normal, tangent);
         Material hit_material = g_materials[OUT.material_index];
 
         float3 emissive_factor = UnpackRGBE(hit_material.emissive_factor);
@@ -98,13 +100,6 @@ void GetGeometryDataFromPrimaryRay(RayDesc ray_desc, PrimaryRayPayload ray_paylo
             // -------------------------------------------------------------------------------------
             // Determine gbuffer normal value
 
-            float3 normals[] =
-            {
-                OUT.hit_triangle.normal0,
-                OUT.hit_triangle.normal1,
-                OUT.hit_triangle.normal2,
-            };
-            float3 interpolated_normal = GetHitAttribute(normals, ray_payload.barycentrics);
             float3 normal = interpolated_normal;
 
             // -------------------------------------------------------------------------------------
@@ -140,12 +135,7 @@ void GetGeometryDataFromPrimaryRay(RayDesc ray_desc, PrimaryRayPayload ray_paylo
             // Calculate normal from normal map
             if (tweak.enable_normal_maps)
             {
-                float3 tangents[] = {
-                    OUT.hit_triangle.tangent0.xyz,
-                    OUT.hit_triangle.tangent1.xyz,
-                    OUT.hit_triangle.tangent2.xyz,
-                };
-                float3 tangent = GetHitAttribute(tangents, ray_payload.barycentrics);
+                
                 float3 bitangent = cross(interpolated_normal, tangent) * OUT.hit_triangle.tangent0.w;
 
                 // Bring the normal map sample from tangent space to world space


### PR DESCRIPTION
Fix for incorrect normal direction calculation for overlay textures by rotating triangle tangents by face orientation (to match rotated uv coordinates).  Also moved interpolating normal and tangent data into GetHitMaterialAndUVs and added interpolated data as return values.