### PR TITLE
fix automap aspect ratio

### DIFF
--- a/RT/RTgr.c
+++ b/RT/RTgr.c
@@ -186,7 +186,7 @@ int gr_set_mode(u_int32_t mode)
 	grd_curscreen->sc_mode = mode;
 	grd_curscreen->sc_w = w;
 	grd_curscreen->sc_h = h;
-	grd_curscreen->sc_aspect = fixdiv(GameCfg.AspectX, GameCfg.AspectY);
+	grd_curscreen->sc_aspect = fixdiv(grd_curscreen->sc_w * GameCfg.AspectX, grd_curscreen->sc_h * GameCfg.AspectY);
 	gr_init_canvas(&grd_curscreen->sc_canvas, d_realloc(gr_bm_data, w * h), BM_RTDX12, w, h);
 	gr_set_current_canvas(NULL);
 

--- a/d1/arch/ogl/gr.c
+++ b/d1/arch/ogl/gr.c
@@ -638,7 +638,7 @@ int gr_set_mode(u_int32_t mode)
 	grd_curscreen->sc_mode = mode;
 	grd_curscreen->sc_w = w;
 	grd_curscreen->sc_h = h;
-	grd_curscreen->sc_aspect = fixdiv(GameCfg.AspectX, GameCfg.AspectY);
+	grd_curscreen->sc_aspect = fixdiv(grd_curscreen->sc_w * GameCfg.AspectX, grd_curscreen->sc_h * GameCfg.AspectY);
 	gr_init_canvas(&grd_curscreen->sc_canvas, d_realloc(gr_bm_data,w*h), BM_OGL, w, h);
 	gr_set_current_canvas(NULL);
 


### PR DESCRIPTION
g3_start_frame (used by automap among others) expects grd_curscreen->sc_aspect to be the pixel aspect ratio (i.e., 1_0f in a mode with square pixels) and not the screen aspect ratio

otherwise on a 16:9 screen automap shapes end up squished horizontally by a factor of 9/16

this change makes the sc_aspect setup code match what is done in other source ports (and also matches d1\arch\sdl\gr.c)