### PR TITLE
Fix for compressed textures with less than 8 bits per pixel (ex:bc4)

### DIFF
--- a/RT/Renderer/Backend/DX12/src/ImageReadWrite.cpp
+++ b/RT/Renderer/Backend/DX12/src/ImageReadWrite.cpp
@@ -279,8 +279,6 @@ RT_Image RT_LoadDDSFromMemory(RT_String memory)
 	result.pitch     = header->pitchOrLinearSize;
 	result.mip_count = RT_MAX(1, header->mipMapCount);
 
-	size_t bytes_per_pixel = bits_per_pixel / 8;
-
 	char *mip_at = data + sizeof(uint32_t) + sizeof(DDS_HEADER) + (header_dxt10 ? sizeof(DDS_HEADER_DXT10) : 0);
 	uint32_t mip_width  = result.width;
 	uint32_t mip_height = result.height;
@@ -295,7 +293,7 @@ RT_Image RT_LoadDDSFromMemory(RT_String memory)
 		result.mips[mip_index] = mip_at;
 
 		// NOTE(daniel): There is an assumption here that rows are tightly packed, it seems.
-		mip_at += mip_width*mip_height*bytes_per_pixel;
+		mip_at += (mip_width * mip_height * bits_per_pixel) / 8;
 		mip_width  /= 2;
 		mip_height /= 2;
 	}

--- a/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
+++ b/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
@@ -2207,7 +2207,7 @@ namespace
 			RT_Image image = RT_LoadImageFromDisk(temp, path, 4, false);
 
 			g_d3d.blue_noise_textures[blue_noise_index] = RT_CreateTexture(Utf16FromUtf8(temp, path), DXGI_FORMAT_R8G8B8A8_UNORM, D3D12_RESOURCE_FLAG_NONE, (size_t)image.width, (uint32_t)image.height);
-			UploadTextureData(g_d3d.blue_noise_textures[blue_noise_index], image.width, image.height, 4, image.mips, 1);
+			UploadTextureData(g_d3d.blue_noise_textures[blue_noise_index], image.width, image.height, 32, image.mips, 1);
 
 			for (size_t frame_index = 0; frame_index < BACK_BUFFER_COUNT; frame_index++)
 			{
@@ -3444,11 +3444,11 @@ RT_ResourceHandle RenderBackend::UploadTexture(const RT_UploadTextureParams& tex
 		case RT_TextureFormat_BC7_SRGB:   format = DXGI_FORMAT_BC7_UNORM_SRGB;        is_dxt_format = true; break;
 	}
 
-	size_t bytes_per_pixel = DDSBitsPerPixel(format) / 8;
+	size_t bits_per_pixel = DDSBitsPerPixel(format);
 
 	if (!image.pitch)
 	{
-		image.pitch = (uint32_t)(image.width*bytes_per_pixel);
+		image.pitch = (uint32_t)( ( image.width * bits_per_pixel ) / 8 );
 	}
 
 	uint32_t resource_mip_count = RT_MAX(1, image.mip_count);
@@ -3481,7 +3481,7 @@ RT_ResourceHandle RenderBackend::UploadTexture(const RT_UploadTextureParams& tex
 		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, 
 		(uint16_t)resource_mip_count);
 
-	UploadTextureData(resource.texture, image.width, image.height, bytes_per_pixel, image.mips, upload_mip_count);
+	UploadTextureData(resource.texture, image.width, image.height, bits_per_pixel, image.mips, upload_mip_count);
 
 	if (generate_mips)
 	{

--- a/RT/Renderer/Backend/DX12/src/Resource.cpp
+++ b/RT/Renderer/Backend/DX12/src/Resource.cpp
@@ -231,7 +231,7 @@ namespace RT
 		ResourceTransition(command_list, dst, dst_state);
 	}
 
-	void UploadTextureData(ID3D12Resource* dst, size_t width, size_t height, size_t bytes_per_pixel, void *const *mips, size_t mip_count)
+	void UploadTextureData(ID3D12Resource* dst, size_t width, size_t height, size_t bits_per_pixel, void *const *mips, size_t mip_count)
 	{
 		size_t mip_width  = width;
 		size_t mip_height = height;
@@ -252,7 +252,7 @@ namespace RT
 			uint8_t *src_at = (uint8_t *)mips[mip_index];
 			uint8_t *dst_at = alloc.ptr;
 
-			size_t src_byte_size     = mip_width*mip_height*bytes_per_pixel;
+			size_t src_byte_size = (mip_width * mip_height * bits_per_pixel) / 8;
 			size_t src_row_byte_size = src_byte_size / dst_row_count;
 
 			size_t dst_pitch = pitch_footprint.Footprint.RowPitch;


### PR DESCRIPTION
Compressed textures with less than 8 bits per pixel like bc4 would not load correctly.  This was due to the fact that pixel size was stored in number of bytes per pixel.  bc4 has 0.5 bytes per pixel and would get truncated to 0 when stored in a integer format.  Fixed by storing in number of bits per pixel and only converting to total bytes when needed.