### PR TITLE
Fix for cloaked ships showing as green instead of black like original game.

### DIFF
--- a/RT/RTgr.c
+++ b/RT/RTgr.c
@@ -994,20 +994,22 @@ void RT_DrawSubPolyModel(RT_ResourceHandle submodel, const RT_Mat4* const submod
 {
 	if (RT_RESOURCE_HANDLE_VALID(submodel))
 	{
+		float component = 1.0f;
 		float alpha = 1.0f;
 		if (grd_curcanv->cv_fade_level < GR_FADE_OFF)
 		{
+			component = 0.0f;	// cloaked ships should have black materials
 			alpha = 1.0f - (float)grd_curcanv->cv_fade_level / ((float)GR_FADE_LEVELS - 1.0f);
 		}
 
-		RT_Vec4 color = { 1, 1, 1, alpha };
+		RT_Vec4 color = { component, component, component, alpha };
 
 		RT_RenderMeshParams params =
 		{
-			.key         = key,
+			.key = key,
 			.mesh_handle = submodel,
-			.transform   = submodel_transform,
-			.color       = RT_PackRGBA(color),
+			.transform = submodel_transform,
+			.color = RT_PackRGBA(color),
 		};
 		RT_RaytraceMeshEx(&params);
 	}


### PR DESCRIPTION
Updated RTgr::RT_DrawSubPolyModel to set mesh color to black when rendering is translucent to match original game.  Currently cloaked ships are too easy to see.  I've looked around in the game and this change doesn't seem to cause any unwanted artifacts elsewhere.

![scrn0027](https://github.com/BredaUniversityGames/DXX-Raytracer/assets/4073396/1bda7eeb-91ed-46a8-a4c0-20b78d61f3d4)
![scrn0029](https://github.com/BredaUniversityGames/DXX-Raytracer/assets/4073396/60f970a7-898c-4fc9-ba86-d62725581ed6)
