### PR TITLE
New Feature: Dynamic Texture Loading

### DIFF
--- a/RT/Game/level.c
+++ b/RT/Game/level.c
@@ -14,7 +14,9 @@
 
 #include "Core/MiniMath.h"
 #include "Core/Arena.h"
+#include "Core/String.h"
 #include "RTgr.h"
+#include "RTmaterials.h"
 #include "Renderer.h"
 #include "Lights.h"
 
@@ -114,6 +116,14 @@ RT_ResourceHandle RT_UploadLevelGeometry()
 {
 	RT_ResourceHandle level_handle = {0};
 
+	// set all textures next/future state to not loaded
+	for (uint16_t bm_index = 1; bm_index < MAX_BITMAP_FILES; bm_index++)
+	{
+		RT_Material* def = &g_rt_materials[bm_index];
+		if (!def->always_load_texture)
+			def->texture_load_state_next = RT_MaterialTextureLoadState_Unloaded;
+	}
+
 	RT_ArenaMemoryScope(&g_thread_arena)
 	{
 		RT_Vertex* verts = RT_ArenaAllocArray(&g_thread_arena, Num_segments * 6 * 4, RT_Vertex);
@@ -203,6 +213,67 @@ RT_ResourceHandle RT_UploadLevelGeometry()
 				}
 				
 				RT_ExtractLightsFromSide(s, &verts[vertex_offset], triangles[num_triangles - 1].normal0, seg_id);
+
+				// Set tmaps next/future state to loaded so they will be loaded into memory
+				for (char topbottom = 0; topbottom < 2; topbottom++)
+				{
+					// convert tmap_num to bitmap index
+
+					ushort bm_index;
+					if (topbottom == 0)
+						bm_index = Textures[s->tmap_num & 0x3FFF].index;
+					else if ( (s->tmap_num2 & 0x3FFF) != 0)
+						bm_index = Textures[s->tmap_num2 & 0x3FFF].index;
+					else
+					{
+						// No overlay texture found
+						continue;
+					}
+
+					
+					// get the bitmap name
+					char bitmap_name[13];
+					piggy_get_bitmap_name(bm_index, bitmap_name);
+					
+					// check if material is part of an animation sequence and set all the frames of the material to load as well
+					const char* pound_pos = strchr(bitmap_name, '#');
+					if (pound_pos)
+					{
+						// texture animation found
+						int char_count = pound_pos - bitmap_name;  // subtract the two pointers to get the length
+
+						char animation_root_name[13];
+						RT_SaneStrncpy(animation_root_name, bitmap_name, char_count + 2);
+
+						int frame_num = 0;
+						char animation_frame_name[13];
+						bitmap_index frame_index;
+						frame_index.index = 0;
+
+						//
+						do
+						{
+							sprintf(animation_frame_name, "%s%d", animation_root_name, frame_num);
+
+							frame_index = piggy_find_bitmap(animation_frame_name);
+
+							RT_Material* def = &g_rt_materials[frame_index.index];
+							if (frame_index.index != 0 && !def->always_load_texture)
+								def->texture_load_state_next = RT_MaterialTextureLoadState_Loaded;
+
+							frame_num++;
+
+						} while (frame_index.index != 0);
+					}
+					else // not part of animation sequence... just set the one texture to load
+					{
+						// set this material to load
+						RT_Material* def = &g_rt_materials[bm_index];
+						if (!def->always_load_texture)
+							def->texture_load_state_next = RT_MaterialTextureLoadState_Loaded;
+					}
+				}
+				
 			}
 		}
 
@@ -219,6 +290,9 @@ RT_ResourceHandle RT_UploadLevelGeometry()
 		RT_LOGF(RT_LOGSERVERITY_INFO, "UPLOADING MESH >>\n");
 		level_handle = RT_UploadMesh(&params);
 		RT_LOGF(RT_LOGSERVERITY_INFO, "UPLOADING MESH OK\n");
+
+		// load and unload materials based on if they are needed for this level.
+		RT_SyncMaterialStates();
 	}
 
 	return level_handle;
@@ -249,6 +323,7 @@ bool RT_LoadLevel()
 		assert(!RT_RESOURCE_HANDLE_VALID(g_level_resource));
 		// Load level geometry
 		g_level_resource = RT_UploadLevelGeometry();
+		RT_ResetLightEmission();		// added this here as resetting light emission was getting skipped when doing a level warp
 		g_active_level = Current_level_num;
 
 		return RT_RESOURCE_HANDLE_VALID(g_level_resource);

--- a/RT/RTmaterials.c
+++ b/RT/RTmaterials.c
@@ -240,6 +240,120 @@ void RT_InitAllBitmaps(void)
 	// This function creates all materials for all GameBitmaps. It has no insight into
 	// the indirection of the Textures / ObjBitmaps / ObjBitmapPtrs arrays.
 	// - Daniel 01/03/2023
+
+	// define a list of textures that always need to be loaded (sprites for example that can spawn at anytime)
+	char texture_always_load_list[][13] = //{"none"};
+	{
+		"blob01#0","blob01#1","blob01#2","blob01#3","blob01#4",
+		"blob02#0","blob02#1","blob02#2","blob02#3","blob02#4",
+		"blob03#0","blob03#1","blob03#2","blob03#3","blob03#4",
+		"blown01","blown02","blown03","blown04","blown05","blown06","blown07",
+		"cloak#0","cloak#1","cloak#2","cloak#3","cloak#4","cloak#5","cloak#6","cloak#7","cloak#8","cloak#9","cloak#10","cloak#11","cloak#12","cloak#13","cloak#14","cloak#15",
+		"cmissil1#0","cmissil1#1","cmissil1#2","cmissil1#3","cmissil1#4","cmissil1#5","cmissil1#6","cmissil1#7","cmissil1#8","cmissil1#9","cmissil1#10","cmissil1#11","cmissil1#12","cmissil1#13","cmissil1#14",
+		"cmissil2#0","cmissil2#1","cmissil2#2","cmissil2#3","cmissil2#4","cmissil2#5","cmissil2#6","cmissil2#7","cmissil2#8","cmissil2#9","cmissil2#10","cmissil2#11","cmissil2#12","cmissil2#13","cmissil2#14",
+		"exp03#0","exp03#1","exp03#2","exp03#3","exp03#4",
+		"exp06#0","exp06#1","exp06#2","exp06#3","exp06#4","exp06#5","exp06#6","exp06#7","exp06#8","exp06#9","exp06#10","exp06#11",
+		"exp09#0","exp09#1","exp09#2","exp09#3","exp09#4",
+		"exp10#0","exp10#1","exp10#2","exp10#3","exp10#4",
+		"exp11#0","exp11#1","exp11#2","exp11#3","exp11#4",
+		"exp13#0","exp13#1","exp13#2","exp13#3","exp13#4","exp13#5","exp13#6","exp13#7","exp13#8","exp13#9","exp13#10","exp13#11","exp13#12","exp13#13","exp13#14","exp13#15","exp13#16",
+		"exp15#0","exp15#1","exp15#2","exp15#3","exp15#4","exp15#5","exp15#6","exp15#7","exp15#8","exp15#9","exp15#10","exp15#11","exp15#12","exp15#13","exp15#14","exp15#15","exp15#16",
+		"exp17#0","exp17#1","exp17#2","exp17#3","exp17#4","exp17#5","exp17#6","exp17#7","exp17#8","exp17#9","exp17#10","exp17#11","exp17#12","exp17#13","exp17#14","exp17#15","exp17#16",
+		"exp18#0","exp18#1","exp18#2","exp18#3","exp18#4","exp18#5","exp18#6","exp18#7","exp18#8",
+		"exp19#0","exp19#1","exp19#2","exp19#3","exp19#4","exp19#5","exp19#6","exp19#7","exp19#8","exp19#9","exp19#10",
+		"exp20#0","exp20#1","exp20#2","exp20#3","exp20#4","exp20#5","exp20#6","exp20#7","exp20#8","exp20#9",
+		"exp21#0","exp21#1","exp21#2","exp21#3","exp21#4","exp21#5","exp21#6","exp21#7","exp21#8","exp21#9","exp21#10","exp21#11","exp21#12",
+		"exp22#0","exp22#1","exp22#2","exp22#3","exp22#4","exp22#5","exp22#6","exp22#7","exp22#8","exp22#9",
+		"fusion#0","fusion#1","fusion#2","fusion#3","fusion#4","fusion#5","fusion#6","fusion#7","fusion#8","fusion#9","fusion#10","fusion#11","fusion#12","fusion#13","fusion#14",
+		"gauge01#0","gauge01#1","gauge01#2","gauge01#3","gauge01#4","gauge01#5","gauge01#6","gauge01#7","gauge01#8","gauge01#9","gauge01#10","gauge01#11","gauge01#12","gauge01#13","gauge01#14","gauge01#15","gauge01#16","gauge01#17","gauge01#18","gauge01#19",
+		"gauge02#0","gauge02#1","gauge02#2","gauge02#3","gauge02#4",
+		"gauge03","gauge04","gauge05",
+		"gauge06#0","gauge06#1","gauge06#2","gauge06#3","gauge06#4","gauge06#5","gauge06#6","gauge06#7",
+		"gauge07","gauge08","gauge09","gauge10","gauge11","gauge12","gauge13","gauge14","gauge15","gauge16","gauge17",
+		"gauge18#0","gauge18#1","gauge18#2",
+		"hmissil1#0","hmissil1#1","hmissil1#2","hmissil1#3","hmissil1#4","hmissil1#5","hmissil1#6","hmissil1#7","hmissil1#8","hmissil1#9","hmissil1#10","hmissil1#11","hmissil1#12","hmissil1#13","hmissil1#14",
+		"hmissil2#0","hmissil2#1","hmissil2#2","hmissil2#3","hmissil2#4","hmissil2#5","hmissil2#6","hmissil2#7","hmissil2#8","hmissil2#9","hmissil2#10","hmissil2#11","hmissil2#12","hmissil2#13","hmissil2#14",
+		"hostage#0","hostage#1","hostage#2","hostage#3","hostage#4","hostage#5","hostage#6","hostage#7",
+		"invuln#0","invuln#1","invuln#2","invuln#3","invuln#4","invuln#5","invuln#6","invuln#7","invuln#8","invuln#9","invuln#10","invuln#11","invuln#12","invuln#13","invuln#14","invuln#15",
+		"key01#0","key01#1","key01#2","key01#3","key01#4","key01#5","key01#6","key01#7","key01#8","key01#9","key01#10","key01#11","key01#12","key01#13","key01#14",
+		"key02#0","key02#1","key02#2","key02#3","key02#4","key02#5","key02#6","key02#7","key02#8","key02#9","key02#10","key02#11","key02#12","key02#13","key02#14",
+		"key03#0","key03#1","key03#2","key03#3","key03#4","key03#5","key03#6","key03#7","key03#8","key03#9","key03#10","key03#11","key03#12","key03#13","key03#14",
+		"laser#0","laser#1","laser#2","laser#3","laser#4","laser#5","laser#6","laser#7","laser#8","laser#9","laser#10","laser#11","laser#12","laser#13","laser#14",
+		"life01#0","life01#1","life01#2","life01#3","life01#4","life01#5","life01#6","life01#7","life01#8","life01#9","life01#10","life01#11","life01#12","life01#13","life01#14",
+		"lives",
+		"misc17#0","misc17#1","misc17#2","misc17#3","misc17#4","misc17#5","misc17#6","misc17#7","misc17#8","misc17#9","misc17#10","misc17#11","misc17#12","misc17#13","misc17#14","misc17#15",
+		"misc060b#0","misc060b#1","misc060b#2","misc060d#0","misc060d#1","misc060d#2",
+		"misc061b#0","misc061b#1","misc061b#2","misc061d#0","misc061d#1","misc061d#2",
+		"misc062b#0","misc062b#1","misc062b#2","misc062d#0","misc062d#1","misc062d#2",
+		"misc065b#0","misc065b#1","misc065b#2","misc065d#0","misc065d#1","misc065d#2",
+		"misc066b#0","misc066b#1","misc066b#2","misc066d#0","misc066d#1","misc066d#2","misc066d#3",
+		"misc068b#0","misc068b#1","misc068b#2","misc068b#3","misc068d#0","misc068d#1","misc068d#2","misc068d#3","misc068d#4","misc068d#5","misc068d#6","misc068d#7","misc068d#8","misc068d#9",
+		"missile",
+		"mmissile#0","mmissile#1","mmissile#2","mmissile#3","mmissile#4","mmissile#5","mmissile#6","mmissile#7","mmissile#8","mmissile#9","mmissile#10","mmissile#11","mmissile#12","mmissile#13","mmissile#14",
+		"mtrl01#0","mtrl01#1","mtrl01#2","mtrl01#3","mtrl01#4","mtrl01#5","mtrl01#6","mtrl01#7","mtrl01#8","mtrl01#9","mtrl01#10","mtrl01#11","mtrl01#12","mtrl01#13","mtrl01#14","mtrl01#15","mtrl01#16","mtrl01#17",
+		"mtrl02#0","mtrl02#1","mtrl01#2","mtrl02#3","mtrl02#4","mtrl02#5","mtrl02#6","mtrl02#7","mtrl02#8","mtrl02#9","mtrl02#10","mtrl02#11",
+		"mtrl03#0","mtrl03#1","mtrl03#2","mtrl03#3","mtrl03#4","mtrl03#5","mtrl03#6","mtrl03#7","mtrl03#8",
+		"muzl02#0","muzl02#1","muzl02#2",
+		"muzl03#0","muzl03#1","muzl03#2",
+		"muzl05#0","muzl05#1","muzl05#2",
+		"muzl06#0","muzl06#1","muzl06#2",
+		"pbomb#0","pbomb#1","pbomb#2","pbomb#3","pbomb#4","pbomb#5","pbomb#6","pbomb#7","pbomb#8","pbomb#9",
+		"pbombs#0","pbombs#1","pbombs#2","pbombs#3","pbombs#4","pbombs#5","pbombs#6","pbombs#7","pbombs#8","pbombs#9",
+		"plasblob#0","plasblob#1","plasblob#2","plasblob#3","plasblob#4","plasblob#5",
+		"plasma#0","plasma#1","plasma#2","plasma#3","plasma#4","plasma#5","plasma#6","plasma#7","plasma#8","plasma#9","plasma#10","plasma#11","plasma#12","plasma#13","plasma#14",
+		"pwr01#0","pwr01#1","pwr01#2","pwr01#3","pwr01#4","pwr01#5","pwr01#6","pwr01#7","pwr01#8","pwr01#9","pwr01#10","pwr01#11","pwr01#12","pwr01#13","pwr01#14",
+		"pwr02#0","pwr02#1","pwr02#2","pwr02#3","pwr02#4","pwr02#5","pwr02#6","pwr02#7",
+		"quad#0","quad#1","quad#2","quad#3","quad#4","quad#5","quad#6","quad#7","quad#8","quad#9","quad#10","quad#11","quad#12","quad#13","quad#14",
+		"rbot006","rbot007","rbot008","rbot009","rbot010","rbot011","rbot012","rbot018","rbot019","rbot020","rbot021",
+		"rbot031","rbot032","rbot035","rbot036","rbot037","rbot042","rbot044","rbot045","rbot046","rbot047","rbot048",
+		"rbot049","rbot051","rbot052","rbot053","rbot054","rbot055","rbot056","rbot057","rbot058","rbot059","rbot060",
+		"rbot061","rbot062","rbot063","rbot064","rbot065",
+		"rmap01#0","rmap01#1","rmap01#2","rmap01#3","rmap01#4","rmap01#5","rmap01#6","rmap01#7",
+		"rmap02#0","rmap02#1","rmap02#2",
+		"rmap03#0","rmap03",
+		"rmap04#0","rmap04#1","rmap04#2","rmap04#3","rmap04#4",
+		"sbenergy","sbkb_off","sbkb_on","sbkr_off","sbkr_on","sbky_off","sbky_on",
+		"ship1-1","ship1-2","ship1-3","ship1-4","ship1-5",
+		"ship2-4","ship2-5",
+		"ship3-4","ship3-5",
+		"ship4-4","ship4-5",
+		"ship5-4","ship5-5",
+		"ship6-4","ship6-5",
+		"ship7-4","ship7-5",
+		"ship8-4","ship8-5",
+		"smissile#0","smissile#1","smissile#2","smissile#3","smissile#4","smissile#5","smissile#6","smissile#7","smissile#8","smissile#9","smissile#10","smissile#11","smissile#12","smissile#13","smissile#14",
+		"spark01#0","spark01#1","spark01#2","spark01#3","spark01#4",
+		"spark02#0","spark02#1","spark02#2","spark02#3","spark02#4",
+		"spark03#0","spark03#1","spark03#2","spark03#3","spark03#4",
+		"spark04#0","spark04#1","spark04#2","spark04#3","spark04#4",
+		"spark05#0","spark05#1","spark05#2","spark05#3","spark05#4",
+		"sprdblob",
+		"spread#0","spread#1","spread#2","spread#3","spread#4","spread#5","spread#6","spread#7","spread#8","spread#9","spread#10","spread#11","spread#12","spread#13","spread#14",
+		"targ01#0","targ01#1",
+		"targ02#0","targ02#1","targ02#2",
+		"targ03#0","targ03#1","targ03#2","targ03#3","targ03#4",
+		"targ04#0","targ04#1",
+		"targ05#0","targ05#1","targ05#2",
+		"targ06#0","targ06#1","targ06#2","targ06#3","targ06#4",
+		"vammo#0","vammo#1","vammo#2","vammo#3","vammo#4","vammo#5","vammo#6","vammo#7","vammo#8","vammo#9","vammo#10","vammo#11","vammo#12","vammo#13","vammo#14",
+		"vulcan#0","vulcan#1","vulcan#2","vulcan#3","vulcan#4","vulcan#5","vulcan#6","vulcan#7","vulcan#8","vulcan#9","vulcan#10","vulcan#11","vulcan#12","vulcan#13","vulcan#14",
+	};
+
+	//printf("Found %d Always Load Textures\n", (int)RT_ARRAY_COUNT(texture_always_load_list));
+
+	// mark all the always load materials
+	for (int i = 0; i < RT_ARRAY_COUNT(texture_always_load_list); i++)
+	{
+		bitmap_index game_texture = piggy_find_bitmap(texture_always_load_list[i]);
+		if (game_texture.index > 0) 
+		{
+			g_rt_materials[game_texture.index].always_load_texture = true;
+		}
+		else
+		{
+			printf("Always Load Texture Not Found in Bitmap List: %s\n", texture_always_load_list[i]);
+		}
+	}
 	
 	for (uint16_t bm_index = 1; bm_index < MAX_BITMAP_FILES; bm_index++)
 	{
@@ -305,7 +419,12 @@ void RT_InitAllBitmaps(void)
 			bool default_metalness, default_roughness;
             RT_ParseMaterialDefinitionFile(bm_index, material, paths, &default_metalness, &default_roughness);
 
-			RT_LoadMaterialTexturesFromPaths(bm_index, material, paths, ~0u);
+			if (material->always_load_texture)
+			{
+				// only load textures at this point that always need to be loaded... the rest will be loaded during level load
+				RT_LoadMaterialTexturesFromPaths(bm_index, material, paths, ~0u);
+				material->texture_load_state = RT_MaterialTextureLoadState_Loaded;
+			}
 
 			if (default_metalness && RT_RESOURCE_HANDLE_VALID(material->metalness_texture))
 			{
@@ -445,5 +564,185 @@ int RT_ReloadMaterials(void)
 	g_rt_last_texture_update_time = time(NULL);
 
 	return textures_reloaded;
+}
+
+void RT_SyncMaterialStates(void) 
+{
+
+	for (uint16_t bm_index = 1; bm_index < MAX_BITMAP_FILES; bm_index++)
+	{
+		char bitmap_name[13];
+		piggy_get_bitmap_name(bm_index, bitmap_name);
+
+		// NOTE(daniel): Substance Designer does not like hashtags in names and
+		// turns them into underscores.
+		for (char* c = bitmap_name; *c; c++)
+		{
+			if (*c == '#')
+			{
+				*c = '_';
+			}
+		}
+
+		// Try to load the material definition
+		RT_Material* material = &g_rt_materials[bm_index];
+		RT_MaterialPaths* paths = &g_rt_material_paths[bm_index];
+
+		if (!material->always_load_texture && material->texture_load_state != material->texture_load_state_next)
+		{
+			if (material->texture_load_state == RT_MaterialTextureLoadState_Unloaded && material->texture_load_state_next == RT_MaterialTextureLoadState_Loaded)
+			{
+				// Load the material
+
+				grs_bitmap* bitmap = &GameBitmaps[bm_index];
+
+				if (bitmap->bm_w == 0 ||
+					bitmap->bm_h == 0)
+				{
+					continue;
+				}
+
+				PIGGY_PAGE_IN((bitmap_index) { bm_index });
+
+				RT_ArenaMemoryScope(&g_thread_arena)
+				{
+					if (bitmap->bm_flags & BM_FLAG_RLE)
+					{
+						bitmap = rle_expand_texture(bitmap);
+					}
+
+					if (bitmap->bm_flags & BM_FLAG_RLE)
+					{
+						bitmap = rle_expand_texture(bitmap);
+					}
+
+					// ------------------------------------------------------------------
+					// Initialize all the defaults
+
+					material->metalness = 0.0f;
+					material->roughness = 0.8f;
+					material->emissive_color = RT_Vec3FromScalar(1.0f);
+					material->emissive_strength = 1.0f;
+
+					if (strstr(bitmap_name, "metl"))
+					{
+						material->metalness = 1.0f;
+						material->roughness = 0.5f;
+					}
+
+					snprintf(paths->albedo_texture, sizeof(paths->albedo_texture), "%s_basecolor", bitmap_name);
+					snprintf(paths->normal_texture, sizeof(paths->normal_texture), "%s_normal", bitmap_name);
+					snprintf(paths->metalness_texture, sizeof(paths->metalness_texture), "%s_metallic", bitmap_name);
+					snprintf(paths->roughness_texture, sizeof(paths->roughness_texture), "%s_roughness", bitmap_name);
+					snprintf(paths->emissive_texture, sizeof(paths->emissive_texture), "%s_emissive", bitmap_name);
+
+					// ------------------------------------------------------------------
+
+					memcpy(&g_rt_materials_default[bm_index], material, sizeof(*material));
+					memcpy(&g_rt_material_paths_default[bm_index], paths, sizeof(*paths));
+
+
+					bool default_metalness, default_roughness;
+					RT_ParseMaterialDefinitionFile(bm_index, material, paths, &default_metalness, &default_roughness);
+
+
+					RT_LoadMaterialTexturesFromPaths(bm_index, material, paths, ~0u);
+					material->texture_load_state = RT_MaterialTextureLoadState_Loaded;
+
+
+					if (default_metalness && RT_RESOURCE_HANDLE_VALID(material->metalness_texture))
+					{
+						material->metalness = 1.0f;
+						// AND ALSO make note of this quirk for the defaults, where after all that we should store the default
+						// metalness and roughness if it was affected by whether or not there was a metal/roughness map:
+						g_rt_materials_default[bm_index].metalness = material->metalness;
+					}
+
+					if (default_roughness && RT_RESOURCE_HANDLE_VALID(material->roughness_texture))
+					{
+						material->roughness = 1.0f;
+						// AND ALSO make note of this quirk for the defaults, where after all that we should store the default
+						// metalness and roughness if it was affected by whether or not there was a metal/roughness map:
+						g_rt_materials_default[bm_index].roughness = material->roughness;
+					}
+
+					if (!RT_RESOURCE_HANDLE_VALID(material->albedo_texture))
+					{
+						uint32_t* pixels = dx12_load_bitmap_pixel_data(&g_thread_arena, bitmap);
+
+						material->albedo_texture = RT_UploadTexture(&(RT_UploadTextureParams) {
+							.image.width = bitmap->bm_w,
+								.image.height = bitmap->bm_h,
+								.image.pixels = pixels,
+								.image.format = g_rt_material_texture_slot_formats[RT_MaterialTextureSlot_Albedo],
+								.name = RT_ArenaPrintF(&g_thread_arena, "Game Texture %hu:basecolor (original)", bm_index),
+						});
+
+#ifdef RT_DUMP_GAME_BITMAPS
+						{
+							const char* png_path = RT_ArenaPrintF(&g_thread_arena, "assets/texture_dump/%s.png", bitmap_name);
+							RT_WritePNGToDisk(png_path, bitmap->bm_w, bitmap->bm_h, 4, pixels, 4 * bitmap->bm_w);
+						}
+#endif
+					}
+
+					material->texture_load_state = RT_MaterialTextureLoadState_Loaded;
+
+					RT_UpdateMaterial(bm_index, material);
+				}
+			}
+			else if (material->texture_load_state == RT_MaterialTextureLoadState_Loaded && material->texture_load_state_next == RT_MaterialTextureLoadState_Unloaded)
+			{
+				// Unload the material
+				for (size_t i = 0; i < RT_MaterialTextureSlot_COUNT; i++)
+				{
+					if (RT_RESOURCE_HANDLE_VALID(material->textures[i]))
+						RT_ReleaseTexture(material->textures[i]);
+							
+				}
+				material->texture_load_state = RT_MaterialTextureLoadState_Unloaded;
+
+				// load the original low res texture (for the material viewer)
+
+				grs_bitmap* bitmap = &GameBitmaps[bm_index];
+
+				if (bitmap->bm_w == 0 ||
+					bitmap->bm_h == 0)
+				{
+					continue;
+				}
+
+				PIGGY_PAGE_IN((bitmap_index) { bm_index });
+
+				RT_ArenaMemoryScope(&g_thread_arena)
+				{
+					if (bitmap->bm_flags & BM_FLAG_RLE)
+					{
+						bitmap = rle_expand_texture(bitmap);
+					}
+
+					if (bitmap->bm_flags & BM_FLAG_RLE)
+					{
+						bitmap = rle_expand_texture(bitmap);
+					}
+
+					uint32_t* pixels = dx12_load_bitmap_pixel_data(&g_thread_arena, bitmap);
+
+					material->albedo_texture = RT_UploadTexture(&(RT_UploadTextureParams) {
+						.image.width = bitmap->bm_w,
+							.image.height = bitmap->bm_h,
+							.image.pixels = pixels,
+							.image.format = g_rt_material_texture_slot_formats[RT_MaterialTextureSlot_Albedo],
+							.name = RT_ArenaPrintF(&g_thread_arena, "Game Texture %hu:basecolor (original)", bm_index),
+					});
+				}
+
+				
+				RT_UpdateMaterial(bm_index, material);
+			}
+		}
+
+		
+	}
 }
 

--- a/RT/RTmaterials.h
+++ b/RT/RTmaterials.h
@@ -26,6 +26,7 @@ typedef struct RT_MaterialPaths
 
 RT_API void RT_InitAllBitmaps(void);
 RT_API int RT_ReloadMaterials(void); // Returns how many textures were reloaded
+RT_API void RT_SyncMaterialStates(void);  // Loads and Unloads textures based on what is needed for the current level.
 
 RT_API RT_Material      g_rt_materials     [RT_MAX_TEXTURES];
 RT_API RT_MaterialPaths g_rt_material_paths[RT_MAX_TEXTURES];

--- a/RT/RTmaterials.h
+++ b/RT/RTmaterials.h
@@ -24,12 +24,29 @@ typedef struct RT_MaterialPaths
     };
 } RT_MaterialPaths;
 
+typedef struct RT_MaterialPathsExist
+{
+    union
+    {
+        struct
+        {
+            bool albedo_texture;
+            bool normal_texture;
+            bool metalness_texture;
+            bool roughness_texture;
+            bool emissive_texture;
+        };
+        bool textures[RT_MaterialTextureSlot_COUNT];
+    };
+} RT_MaterialPathsExist;
+
 RT_API void RT_InitAllBitmaps(void);
 RT_API int RT_ReloadMaterials(void); // Returns how many textures were reloaded
 RT_API void RT_SyncMaterialStates(void);  // Loads and Unloads textures based on what is needed for the current level.
 
-RT_API RT_Material      g_rt_materials     [RT_MAX_TEXTURES];
-RT_API RT_MaterialPaths g_rt_material_paths[RT_MAX_TEXTURES];
+RT_API RT_Material           g_rt_materials     [RT_MAX_TEXTURES];
+RT_API RT_MaterialPaths      g_rt_material_paths[RT_MAX_TEXTURES];
+RT_API RT_MaterialPathsExist g_rt_material_paths_exist[RT_MAX_TEXTURES];    // records if a texture actually exists in slots defined in RT_MaterialPaths.  Needed when texture/material is in unloaded state to know one exists without having to try to load it.
 
 // NOTE(daniel): These are just for keeping track of what the default initialized values for these things are.
 // The defaults may later change in code and that might want to be reflected in materials that had non-default

--- a/RT/Renderer/Backend/Common/include/Renderer.h
+++ b/RT/Renderer/Backend/Common/include/Renderer.h
@@ -238,6 +238,12 @@ typedef enum RT_MaterialTextureSlot
     RT_MaterialTextureSlot_COUNT
 } RT_MaterialTextureSlot;
 
+typedef enum RT_MaterialTextureLoadState
+{
+	RT_MaterialTextureLoadState_Unloaded,
+	RT_MaterialTextureLoadState_Loaded
+} RT_MaterialTextureLoadState;
+
 typedef struct RT_Material
 {
 	union
@@ -257,6 +263,9 @@ typedef struct RT_Material
 	RT_Vec3 emissive_color;
 	float emissive_strength;
 	uint32_t flags;
+	bool always_load_texture;
+	RT_MaterialTextureLoadState texture_load_state;
+	RT_MaterialTextureLoadState texture_load_state_next;  // used when loading level to determine if the texture should be loaded or unloaded
 } RT_Material;
 
 typedef struct RT_SceneSettings

--- a/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
+++ b/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
@@ -3520,10 +3520,15 @@ RT_ResourceHandle RenderBackend::UploadMesh(const RT_UploadMeshParams& mesh_para
 void RenderBackend::ReleaseTexture(const RT_ResourceHandle texture_handle)
 {
 	TextureResource* texture_resource = g_texture_slotmap.Find(texture_handle);
-	// Note (Justin): This is a dirty little hack to have the resources released after the current frame finished rendering
-	RT_TRACK_TEMP_OBJECT(texture_resource->texture, &g_d3d.command_queue_direct->GetCommandList());
-	g_d3d.cbv_srv_uav.Free(texture_resource->descriptors);
-	g_texture_slotmap.Remove(texture_handle);
+
+	if (texture_resource)
+	{
+		// Note (Justin): This is a dirty little hack to have the resources released after the current frame finished rendering
+		RT_TRACK_TEMP_OBJECT(texture_resource->texture, &g_d3d.command_queue_direct->GetCommandList());
+		g_d3d.cbv_srv_uav.Free(texture_resource->descriptors);
+		g_d3d.resource_tracker.Release(texture_resource->texture);  // JA: added this line so GPU would release texture memory
+		g_texture_slotmap.Remove(texture_handle);
+	}
 }
 
 void RenderBackend::ReleaseMesh(const RT_ResourceHandle mesh_handle)

--- a/d1/main/gameseq.c
+++ b/d1/main/gameseq.c
@@ -630,6 +630,10 @@ void LoadLevel(int level_num,int page_in_textures)
 
 	level_name = get_level_file(level_num);
 
+	gr_use_palette_table("palette.256");
+
+	show_boxed_message(TXT_LOADING, 0);
+	
 	if (!load_level(level_name))
 	{
 		Current_level_num = level_num;
@@ -641,9 +645,7 @@ void LoadLevel(int level_num,int page_in_textures)
 #endif
 	}
 
-	gr_use_palette_table( "palette.256" );
-
-	show_boxed_message(TXT_LOADING, 0);
+	
 #ifdef RELEASE
 	timer_delay(F1_0);
 #endif
@@ -1124,7 +1126,9 @@ void StartNewLevelSub(int level_num, int page_in_textures, int secret_flag)
 	if (Newdemo_state == ND_STATE_RECORDING) {
 		newdemo_set_new_level(level_num);
 		newdemo_record_start_frame(FrameTime );
-	} 
+	}
+
+	reset_special_effects(); // JA ... test moved from below to ahead of loadlevel
 
 	LoadLevel(level_num, page_in_textures);
 
@@ -1189,7 +1193,7 @@ void StartNewLevelSub(int level_num, int page_in_textures, int secret_flag)
 	if (!(Game_mode & GM_MULTI) && !cheats.enabled)
 		set_highest_level(Current_level_num);
 
-	reset_special_effects();
+	//reset_special_effects();  JA moved above loadlevel so that wall textures are reset so load level knows which textures to load
 
 #ifdef OGL
 	ogl_cache_level_textures();


### PR DESCRIPTION
Added dynamic texture loading during level load to reduce memory footprint on the GPU.  Now only loads textures needed for level instead of entire texture library.

Changes:

Renderer.h
Add new enum RT_MaterialTextureLoadState to specify if material textures are loaded or unloaded.
Add new fields texture_load_state, texture_load_state_next to RT_Material track current/future state of textures.

RTmaterials.h
Add new variable g_rt_material_paths_exist to track if individual textures exist.
Add new method RT_VerifyMaterialTexturesFromPaths to populate g_rt_material_paths_exist

RTmaterials.c
Updated RT_InitAllBitmaps to only load material information, no longer loads texture maps.
Added Function RT_SyncMaterialStates to compare current/future state of material and load/unload it accordingly.

level.c
Updated RT_UploadLevelGeometry() to record what textures are need for the level and then call RT_SyncMaterialStates()
Updated RT_LoadLevel to call RT_ResetLightEmission() to fix bug where blinking end levels lights would not get reset during level warp.

gameseq.c
Updated LoadLevel to move display of Loading (Prepare for Descent) box before the level attempts to load to act as a loading screen now that it takes longer due to textures loading.
Updated StartNewLevelSub to move reset_special_effects() before level load so that wall textures are reset and correct textures will be loaded in.

RenderBackend.cpp
Updated ReleaseTexture to add line g_d3d.resource_tracker.Release(texture_resource->texture) to fix issue with GPU not releasing texture memory.  I found this through trial and error and not 100% certain this is the correct way to deal with this.

NOTE:  This PR also contains fixes for compressed textures with less than 1 byte per pixel.  May want to review/approve that PR first before this one.

