### PR TITLE
Revert "Improved texture sampling to allow for soft/dithered texture edges."

### DIFF
--- a/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
@@ -768,10 +768,6 @@ bool IsHitTransparent(uint instance_idx, uint primitive_idx, float2 barycentrics
 	};
 	float2 uv = GetHitAttribute(uvs, barycentrics);
 	float2 uv_rotated = GetRotatedUVs(orient, uv);
-	float4 color = UnpackRGBA(instance_data.material_color);
-	float4 tri_color = UnpackRGBA(hit_triangle.color);
-	float base_alpha = color.a * tri_color.a;
-	float  dither = RandomSample(pixel_pos, instance_idx);
 
 	// TODO(daniel): Clean this messy silly code up!
 	if (material_index2 != 0xFFFFFFFF)
@@ -787,10 +783,10 @@ bool IsHitTransparent(uint instance_idx, uint primitive_idx, float2 barycentrics
 			return true;
 		}
 
-		if (albedo2.a >= dither)
+		if (albedo2.a > 0.0)
 		{
-			material = g_materials[material_index2];
-			return dither >= base_alpha;
+			material_index = material_index2;
+			uv = uv_rotated;
 		}
 	}
 
@@ -798,7 +794,18 @@ bool IsHitTransparent(uint instance_idx, uint primitive_idx, float2 barycentrics
 	Texture2D tex_albedo = GetTextureFromIndex(material.albedo_index);
 	float4 albedo = tex_albedo.SampleLevel(g_sampler_point_wrap, uv, 0);
 
-	return dither >= albedo.a * base_alpha;
+	if (albedo.a == 0.0)
+	{
+		return true;
+	}
+	else
+	{
+		float4 color = UnpackRGBA(instance_data.material_color);
+		float4 tri_color = UnpackRGBA(hit_triangle.color);
+		float  dither = RandomSample(pixel_pos, instance_idx);
+
+		return dither > color.a * tri_color.a;
+	}
 }
 
 // -----------------------------------------------------------


### PR DESCRIPTION
Sadly, this causes a lot of fireflies on some of the lights in the game with the base game. Here is a video to demonstrate the issue.

It will be left out for build 1.2.0

https://github.com/BredaUniversityGames/DXX-Raytracer/assets/36227602/5baa40a0-13d8-4ce5-ae01-fed069b3b14c

