### PR TITLE
Add Parallax Mapping Support

### DIFF
--- a/RT/RTmaterials.c
+++ b/RT/RTmaterials.c
@@ -47,6 +47,7 @@ char *g_rt_texture_slot_names[RT_MaterialTextureSlot_COUNT] =
 	[RT_MaterialTextureSlot_Metalness] = "metalness",
 	[RT_MaterialTextureSlot_Roughness] = "roughness",
 	[RT_MaterialTextureSlot_Emissive]  = "emissive",
+	[RT_MaterialTextureSlot_Height] = "height",
 };
 
 RT_Material				g_rt_materials				[RT_MAX_TEXTURES];
@@ -122,6 +123,11 @@ static void RT_ParseMaterialDefinitionFile(int bm_index, RT_Material *material, 
 			if (RT_ConfigReadString(&cfg, RT_StringLiteral("emissive_texture"), &string))
 			{
 				RT_CopyStringToBufferNullTerm(string, sizeof(paths->emissive_texture), paths->emissive_texture);
+			}
+
+			if (RT_ConfigReadString(&cfg, RT_StringLiteral("height_texture"), &string))
+			{
+				RT_CopyStringToBufferNullTerm(string, sizeof(paths->height_texture), paths->height_texture);
 			}
 
 			bool has_roughness = RT_ConfigReadFloat(&cfg, RT_StringLiteral("roughness"), &material->roughness);
@@ -477,6 +483,7 @@ void RT_InitAllBitmaps(void)
 			snprintf(paths->metalness_texture, sizeof(paths->metalness_texture), "%s_metallic", bitmap_name);
 			snprintf(paths->roughness_texture, sizeof(paths->roughness_texture), "%s_roughness", bitmap_name);
 			snprintf(paths->emissive_texture, sizeof(paths->emissive_texture), "%s_emissive", bitmap_name);
+			snprintf(paths->height_texture, sizeof(paths->height_texture), "%s_height", bitmap_name);
 
 			// ------------------------------------------------------------------
 

--- a/RT/RTmaterials.h
+++ b/RT/RTmaterials.h
@@ -19,6 +19,7 @@ typedef struct RT_MaterialPaths
 			char metalness_texture[256];
 			char roughness_texture[256];
 			char emissive_texture [256];
+            char height_texture[256];
         };
         char textures[RT_MaterialTextureSlot_COUNT][256];
     };
@@ -35,6 +36,7 @@ typedef struct RT_MaterialPathsExist
             bool metalness_texture;
             bool roughness_texture;
             bool emissive_texture;
+            bool height_texture;
         };
         bool textures[RT_MaterialTextureSlot_COUNT];
     };

--- a/RT/Renderer/Backend/Common/include/Renderer.h
+++ b/RT/Renderer/Backend/Common/include/Renderer.h
@@ -235,6 +235,7 @@ typedef enum RT_MaterialTextureSlot
     RT_MaterialTextureSlot_Metalness,
     RT_MaterialTextureSlot_Roughness,
     RT_MaterialTextureSlot_Emissive,
+	RT_MaterialTextureSlot_Height,
     RT_MaterialTextureSlot_COUNT
 } RT_MaterialTextureSlot;
 
@@ -255,6 +256,7 @@ typedef struct RT_Material
 			RT_ResourceHandle metalness_texture;
 			RT_ResourceHandle roughness_texture;
 			RT_ResourceHandle emissive_texture;
+			RT_ResourceHandle height_texture;
 		};
 		RT_ResourceHandle textures[RT_MaterialTextureSlot_COUNT];
 	};

--- a/RT/Renderer/Backend/DX12/assets/shaders/include_shared/shared_common.hlsl.h
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include_shared/shared_common.hlsl.h
@@ -46,6 +46,7 @@ struct Material
 	uint   metalness_index;
 	uint   roughness_index;
 	uint   emissive_index;
+	uint   height_index;
 	uint   flags;
 	float  metalness_factor;
 	float  roughness_factor;

--- a/RT/Renderer/Backend/DX12/assets/shaders/include_shared/shared_tweakvars.hlsl.h
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include_shared/shared_tweakvars.hlsl.h
@@ -45,6 +45,7 @@ TWEAK_OPTIONS("Metallic/Roughness Sampler",metallic_roughness_sample_linear, 0, 
 TWEAK_BOOL   ("Override Materials",        override_materials,        false)
 TWEAK_FLOAT  ("Override Metallic",         override_metallic,         0,        0,    1)
 TWEAK_FLOAT  ("Override Roughness",        override_roughness,        0.3,      0,    1)
+TWEAK_BOOL   ("Enable Parallax Mapping",   enable_parallax_mapping,   true)
 // ------------------------------------------------------------------------------------------------------------------
 TWEAK_CATEGORY_END()
 

--- a/RT/Renderer/Backend/DX12/src/GlobalDX.h
+++ b/RT/Renderer/Backend/DX12/src/GlobalDX.h
@@ -282,6 +282,9 @@ namespace RT
 		TextureResource  *black_texture;
 		RT_ResourceHandle black_texture_handle;
 
+		TextureResource* gray_texture;
+		RT_ResourceHandle gray_texture_handle;
+
 		TextureResource *default_normal_texture;
 		RT_ResourceHandle pink_checkerboard_texture;
 

--- a/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
+++ b/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
@@ -2336,6 +2336,24 @@ namespace
 		}
 
 		// ------------------------------------------------------------------
+		// Create gray debug texture
+
+		{
+			uint32_t pixels[] = { 0xFF808080 };  // medium gray
+
+			RT_UploadTextureParams gray_texture_params = {};
+			RT_Image& image = gray_texture_params.image;
+			image.width = 1;
+			image.height = 1;
+			image.pixels = pixels;
+			image.format = RT_TextureFormat_RGBA8;
+			gray_texture_params.name = "Gray Texture";
+
+			g_d3d.gray_texture_handle = RenderBackend::UploadTexture(gray_texture_params);
+			g_d3d.gray_texture = g_texture_slotmap.Find(g_d3d.gray_texture_handle);
+		}
+
+		// ------------------------------------------------------------------
 		// Create default normal texture
 
 		{
@@ -3573,6 +3591,11 @@ uint16_t RenderBackend::UpdateMaterial(uint16_t material_index, const RT_Materia
 		if (!emissive)
 			emissive = g_d3d.black_texture;
 
+		TextureResource* height = g_texture_slotmap.Find(material->height_texture);
+
+		if (!height)
+			height = g_d3d.gray_texture;
+
 		RT_Vec3 emissive_factor = material->emissive_color;
 		emissive_factor = RT_Vec3Muls(emissive_factor, material->emissive_strength);
 
@@ -3582,6 +3605,7 @@ uint16_t RenderBackend::UpdateMaterial(uint16_t material_index, const RT_Materia
 		gpu_material->metalness_index  = metalness->descriptors.heap_offset;
 		gpu_material->roughness_index  = roughness->descriptors.heap_offset;
 		gpu_material->emissive_index   = emissive->descriptors.heap_offset;
+		gpu_material->height_index     = height->descriptors.heap_offset;
 		gpu_material->metalness_factor = material->metalness;
 		gpu_material->roughness_factor = material->roughness;
 		gpu_material->emissive_factor  = RT_PackRGBE(emissive_factor);

--- a/d1/assets/render_presets/default.vars
+++ b/d1/assets/render_presets/default.vars
@@ -66,3 +66,4 @@ albedo_sample_linear = 0
 gamma = -0.300000
 bloom_amount = 0.025000
 exposure = 0.100000
+enable_parallax_mapping = 1

--- a/d1/assets/render_presets/gamer.vars
+++ b/d1/assets/render_presets/gamer.vars
@@ -59,3 +59,4 @@ motion_blur_jitter = 1.000000
 albedo_sample_linear = 0
 gamma = -0.300000
 bloom_amount = 0.150000
+enable_parallax_mapping = 1

--- a/d1/main/menu.c
+++ b/d1/main/menu.c
@@ -1458,6 +1458,9 @@ void raytrace_config()
 	int headlight_brightness = (int)roundf(g_headlights.brightness * 5.0f);
 	int opt_gr_headlight_brightness = nitems;
 	m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = "Headlight Brightness:"; m[nitems].value = headlight_brightness; m[nitems].min_value = 0; m[nitems].max_value = 15; nitems++;
+	
+	int opt_gr_enable_parallax = nitems;
+	m[nitems].type = NM_TYPE_CHECK; m[nitems].text = "Parallax Mapping"; m[nitems].value = RT_GetIntFromConfig(config, RT_StringLiteral("enable_parallax_mapping")); nitems++;
 
 	RT_ASSERT(nitems <= RT_ARRAY_COUNT(m));
 
@@ -1546,6 +1549,8 @@ void raytrace_config()
 		RT_ConfigWriteFloat(config, RT_StringLiteral("gamma"), -1.0 + ((float)m[opt_gr_gamma].value/10.0f));
 		RT_ConfigWriteFloat(config, RT_StringLiteral("vignette_scale"), ((float)m[opt_gr_vignette_scale].value)/10.0f);
 		RT_ConfigWriteFloat(config, RT_StringLiteral("vignette_strength"), ((float)m[opt_gr_vignette_strength].value)/10.0f);
+
+		RT_ConfigWriteInt(config, RT_StringLiteral("enable_parallax_mapping"), m[opt_gr_enable_parallax].value);
 
 		RT_SerializeConfigToFile(config, RT_RENDER_SETTINGS_CONFIG_FILE); 
 		config->last_modified_time = RT_GetHighResTime().value;


### PR DESCRIPTION
This pull request adds parallax mapping support.  This works by added a new height texture slot (grayscale) and using that texture to offset all the other texture maps by a calculated parallax to give the impression of depth/height for surfaces.  The supplied height texture should use middle gray for base surface.  Darker shades of gray will appear to recess into the surface, lighter shades will appear to pop out of the surface.  This addition is currently limited to parallaxing the color channel and does not update the lighting and depth calculations which can result in some minor graphical oddities.  This addition does result in a 2-3% performance hit.  I added a toggle in the raytracing settings to allow for disabling of the effect.

Off
![scrn0061](https://github.com/user-attachments/assets/508d64cf-67ad-4db4-b173-019431c7b84a)
On
![scrn0059](https://github.com/user-attachments/assets/1e5a1c5a-31ec-4d30-920d-c2847fe4da79)
Off
![scrn0064](https://github.com/user-attachments/assets/8420a754-9205-44b3-b048-9f690cf60615)
On
![scrn0063](https://github.com/user-attachments/assets/65abe46c-48f1-41fb-9ed4-313e0c2a42f6)

![scrn0056](https://github.com/user-attachments/assets/e1dd03a7-95b0-4d1d-8551-f2687d788976)



Changes:

RTmaterials.h
- Added new member height_texture to RT_MaterialPaths

RTmaterials.c
- Added new height texture slot to g_rt_texture_slot_names
- Update RT_ParseMaterialDefinitionFile to also look for height texture
- Update RT_InitAllBitmaps to also look for height texture

Renderer.h
- Added member RT_MaterialTextureSlot_Height to RT_MaterialTextureSlot
- Added member height_texture to RT_Material and RT_MaterialPathsExist

shared_common.hlsl.h
- Added member height_index to struct Material

primary_ray.hlsli
- Updated GetHitGeometryFromRay to sample the new height texture and offset the uv coordinates of the surface to give the impression of depth.  It does this by starting the depth check at the middle gray value and comparing that to the sampled height value at the original uv coordinate.  If the sampled value is above this starting value the shader will search toward the ray  direction (popout), if the sampled value is below it will search away from the ray direction (recess).  This search will consist of offsetting the uv coordinate by a predetermined amount and then sampling the height again.  It will continue to do this until the sample is on the opposite side of the height value it started on.  The last step is to take this new uv offset and blend it with the uv offset from the previous loop.

GlobalDX.h
- Updated struct D3D12State to add new gray_texture slots.  These slots are necessary to hold a middle gray texture to be loaded into the height slot of any material that does not specify a height texture.

RenderBackend.cpp
- Updated CreateDefaultTextures() to create a new gray texture to be used in the height slot of any material that doesn't specify a height texture.
- Updated UpdateMaterial() to assign new gray texture to height slot of any material that doesn't specify a height texture.

menu.c
- Added to menu option "Parallax Mapping" to enable or disable parallaxing feature

shared_tweakvars.hlsl.h
- Added new tweakvar "enable_parallax_mapping" to control if parallax mapping feature is enabled.


Issues:
This addition does create some minor graphical issues to be aware of and may need additional work to address.  As this update does not update the lighting calculations the lighting does not move with the parallaxing texture resulting in the lighting appearing to "slide" against texture.  Most noticeable in darker areas with a bright light source like a flare, brightly lit areas the issue isn't really noticeable.

The addition of depth can cause textures that were not meant to wrap to be wrapped like the below light texture.  It might be possible to add a new mirrored texture sampler to address this issue, but is not part of this PR.
![scrn0065](https://github.com/user-attachments/assets/e97463cf-209d-4300-bebd-b4759a2fba0b)
![scrn0066](https://github.com/user-attachments/assets/f28c689f-51d4-4103-a455-649fd1fe433b)