### PR TITLE
Fix for issue with tangents rotating the wrong direction with mirrored uv coordinates.

### DIFF
--- a/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
@@ -714,9 +714,24 @@ void GetHitMaterialAndUVs(InstanceData instance_data, RT_Triangle hit_triangle, 
 		if (albedo2.a > 0.0)
 		{
 			material_index = material_index2;
-			if(orient != 0)
+			if (orient != 0)
 			{
 				uv = uv_rotated;
+
+				// Calculate UV direction vectors
+				float2 uvEdge1 = hit_triangle.uv1 - hit_triangle.uv0;
+				float2 uvEdge2 = hit_triangle.uv2 - hit_triangle.uv0;
+
+				// Compute the determinant
+				float det = uvEdge1.x * uvEdge2.y - uvEdge1.y * uvEdge2.x;
+
+				if (det < 0.0 && orient % 2 == 1)
+				{
+					// if the uv coords are mirrored and the orientation is 1 or 3 (90 and 270 degress) add 180 degress
+					// this is because 90 and 270 need to be swapped when uvs are mirrored and its easier to just add 180 degress.
+					orient += 2;
+				}
+
 				tangent = GetRotatedTangent(orient, normal, tangent);
 			}
 		}


### PR DESCRIPTION
Discovered an issue when rotating tangents for overlay textures.  When the surfaces uv coordinates were mirrored the tangent would rotate in the wrong direction resulting in incorrect lighting and parallax.  Added check for mirrored uv coordinates and set orientation correctly when detected.

Incorrect: Mirrored texture on left has inverted normals.
![scrn0072](https://github.com/user-attachments/assets/99757911-2012-46cd-a2ef-4df9b400a9a6)

Corrected: Mirrored texture on left now has correct normals that match right side.
![scrn0070](https://github.com/user-attachments/assets/00625149-7182-4c4c-82e7-56f1c761d32d)

