### PR TITLE
Fix for alpha of base texture taking precedence over alpha of overlay texture

### DIFF
--- a/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
@@ -802,7 +802,7 @@ bool IsHitTransparent(uint instance_idx, uint primitive_idx, float2 barycentrics
 			return true;
 		}
 
-		if ( dither >= albedo2.a )
+		if ( dither < albedo2.a )
 		{
 			material = g_materials[material_index2];
 			return dither >= base_alpha;


### PR DESCRIPTION
Fix for issue where the alpha channel of a base texture would take precedence over alpha channel of overlay texture.

Wrong
![scrn0126](https://github.com/user-attachments/assets/02b30d55-a31c-4516-90f2-93ce6d9a5c77)

Corrected
![scrn0127](https://github.com/user-attachments/assets/cc4d41b9-c310-4c0a-bea9-0480cbb1c8a6)
