### PR TITLE
Changed texture location search order

### DIFF
--- a/RT/RTmaterials.c
+++ b/RT/RTmaterials.c
@@ -96,13 +96,13 @@ static void RT_ParseMaterialDefinitionFile(int bm_index, RT_Material *material, 
 		RT_Config cfg;
 		RT_InitializeConfig(&cfg, &g_thread_arena);
 
-		// first try to load the material definition from the vault files
-		bool loaded = RT_DeserializeConfigFromVault(&cfg, material_file);
+		// first try to load the material definition from file
+		bool loaded = RT_DeserializeConfigFromFile(&cfg, material_file);
 
-		// if fails, try from file.
+		// if fails, try from the vaults.
 		if (!loaded)
 		{
-			loaded = RT_DeserializeConfigFromFile(&cfg, material_file);
+			loaded = RT_DeserializeConfigFromVault(&cfg, material_file);
 		}
 		
 		if (loaded)

--- a/RT/Renderer/Backend/DX12/src/ImageReadWrite.cpp
+++ b/RT/Renderer/Backend/DX12/src/ImageReadWrite.cpp
@@ -57,16 +57,13 @@ RT_Image RT_LoadImageFromDisk(RT_Arena *arena, const char *path_c, int required_
 		file_buffer.bytes = nullptr;
 		file_buffer.count = 0;
 
-		// first try to load from vault
-		if (RT_GetFileFromVaults(path, file_buffer))
+		// first try to load from disk
+		result.pixels = stbi_load(path_c, &w, &h, &channel_count, required_channel_count);
+
+		// try to load from the vaults
+		if (!result.pixels && RT_GetFileFromVaults(path, file_buffer))
 		{
 			result.pixels = stbi_load_from_memory((unsigned char*)(file_buffer.bytes),file_buffer.count,&w,&h, &channel_count, required_channel_count);
-		}
-
-		// try to load from disk
-		if (!result.pixels)
-		{
-			result.pixels = stbi_load(path_c, &w, &h, &channel_count, required_channel_count);
 		}
 
 		if (result.pixels)
@@ -333,14 +330,12 @@ RT_Image RT_LoadDDSFromDisk(RT_Arena *arena, RT_String path)
 	memory.bytes = nullptr;
 	memory.count = 0;
 
-	if (RT_GetFileFromVaults(path, memory))
+	if (RT_ReadEntireFile(arena, path, &memory))
 	{
 
 		loaded = true;
 	}
-
-	
-	else if (RT_ReadEntireFile(arena, path, &memory))
+	else if (RT_GetFileFromVaults(path, memory))
 	{
 		
 		loaded = true;


### PR DESCRIPTION
Changed order that texture locations will be searched.  Files in asset/texture directory will now load before vault files to allow easier mod creation.