### PR TITLE
Fix for incorrect rendering for overlapping segments and improved end level sequence rendering.

### DIFF
--- a/RT/Game/Level.h
+++ b/RT/Game/Level.h
@@ -10,6 +10,6 @@ bool RT_LoadLevel();
 void RT_RenderLevel(RT_Vec3 player_pos);
 bool RT_UnloadLevel();
 
-RT_ResourceHandle RT_UploadLevelGeometry(void);
+bool RT_UploadLevelGeometry(RT_ResourceHandle* level_handle, RT_ResourceHandle* portals_handle);
 
 #endif //_RT_LEVEL_H

--- a/RT/Game/level.c
+++ b/RT/Game/level.c
@@ -24,6 +24,7 @@
 
 // Current active level
 RT_ResourceHandle g_level_resource = { 0 };
+RT_ResourceHandle g_level_with_portals_resource = { 0 };
 int g_active_level = 0;
 
 int m_light_count = 0;
@@ -122,9 +123,8 @@ void RT_ExtractLightsFromSide(side* side, RT_Vertex* vertices, RT_Vec3 normal, i
 	}
 }
 
-RT_ResourceHandle RT_UploadLevelGeometry()
+bool RT_UploadLevelGeometry(RT_ResourceHandle* level_handle, RT_ResourceHandle* portals_handle)
 {
-	RT_ResourceHandle level_handle = {0};
 
 	// set all textures next/future state to not loaded
 	for (uint16_t bm_index = 1; bm_index < MAX_BITMAP_FILES; bm_index++)
@@ -138,6 +138,7 @@ RT_ResourceHandle RT_UploadLevelGeometry()
 	{
 		RT_Vertex* verts = RT_ArenaAllocArray(&g_thread_arena, Num_segments * 6 * 4, RT_Vertex);
 		RT_Triangle* triangles = RT_ArenaAllocArray(&g_thread_arena, Num_segments * 6 * 2, RT_Triangle);
+		RT_Triangle* portal_triangles = RT_ArenaAllocArray(&g_thread_arena, Num_segments * 6 * 2, RT_Triangle);
 
 		// Init lights segment id list
 		for (size_t i = 0; i < _countof(m_lights_seg_ids); ++i) {
@@ -147,6 +148,7 @@ RT_ResourceHandle RT_UploadLevelGeometry()
 		int num_verts = 0;
 		int num_indices = 0; 
 		int num_triangles = 0;
+		int num_portal_triangles = 0;
 
 		int num_mesh = 0;
 		for (int seg_id = 0; seg_id < Num_segments; seg_id++)
@@ -158,7 +160,7 @@ RT_ResourceHandle RT_UploadLevelGeometry()
 				const int vertex_offset = num_verts;
 				const int indices_offset = num_indices;
 
-				side *s = &seg->sides[side_index];
+				side* s = &seg->sides[side_index];
 				int vertnum_list[4];
 				get_side_verts(&vertnum_list, seg_id, side_index);
 
@@ -188,38 +190,65 @@ RT_ResourceHandle RT_UploadLevelGeometry()
 					//assert(vert.uv.x >= -10.0 && vert.uv.x <= 10.0);
 				}
 
-				
+
 				// Mark invisible walls as portals
-				bool should_render = false;
+				bool is_portal = true;
 				if (seg->children[side_index] == -1)
 				{
-					should_render = true;
+					is_portal = false;
 				}
 				else if (s->wall_num != -1)
 				{
-					wall *w = &Walls[s->wall_num];
+					wall* w = &Walls[s->wall_num];
 					// TODO(daniel): What about blastable wallls?
 					if (w->type != WALL_OPEN)
 					{
-						should_render = true;
+						is_portal = false;
 					}
 				}
-				
-				int absolute_side_index = MAX_SIDES_PER_SEGMENT*seg_id + side_index;
-				switch (s->type) 
+
+				int absolute_side_index = MAX_SIDES_PER_SEGMENT * seg_id + side_index;
+
+				// We need to build two different versions of the level mesh.  One with just the visible surfaces and one with both visible surfaces and portal surfaces.
+				// This is to allow ray retracing to disabled.  If you are wondering why we just don't have a second mesh with just the portal surfaces and turn that on 
+				// and off... a mesh only made up of invisible surfaces the size of the level allows rays to trace the entire distance of the level, resulting in weirdness
+				// and massive performance issues.  The portals must be in the same mesh as the regular geometry, which means two copies of the level mesh.
+
+				// if not a portal surface add to regular level geometry
+				if (!is_portal)
 				{
+					switch (s->type)
+					{
 					case SIDE_IS_TRI_13:
-						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 1, 3, absolute_side_index, !should_render,seg_id, seg->children[side_index]);
-						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 1, 2, 3, absolute_side_index, !should_render, seg_id, seg->children[side_index]);
-					break;
-					
+						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 1, 3, absolute_side_index, false, seg_id, seg->children[side_index]);
+						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 1, 2, 3, absolute_side_index, false, seg_id, seg->children[side_index]);
+						break;
+
 					case SIDE_IS_QUAD:
 					case SIDE_IS_TRI_02:
 					default:
-						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 1, 2, absolute_side_index, !should_render, seg_id, seg->children[side_index]);
-						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 2, 3, absolute_side_index, !should_render, seg_id, seg->children[side_index]);
+						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 1, 2, absolute_side_index, false, seg_id, seg->children[side_index]);
+						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 2, 3, absolute_side_index, false, seg_id, seg->children[side_index]);
+						break;
+					}
+				}
+				
+				// if its either a portal or regular surface add to level with portals geometry
+				switch (s->type)
+				{
+				case SIDE_IS_TRI_13:
+					portal_triangles[num_portal_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 1, 3, absolute_side_index, is_portal, seg_id, seg->children[side_index]);
+					portal_triangles[num_portal_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 1, 2, 3, absolute_side_index, is_portal, seg_id, seg->children[side_index]);
+					break;
+
+				case SIDE_IS_QUAD:
+				case SIDE_IS_TRI_02:
+				default:
+					portal_triangles[num_portal_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 1, 2, absolute_side_index, is_portal, seg_id, seg->children[side_index]);
+					portal_triangles[num_portal_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 2, 3, absolute_side_index, is_portal, seg_id, seg->children[side_index]);
 					break;
 				}
+				
 				
 				RT_ExtractLightsFromSide(s, &verts[vertex_offset], triangles[num_triangles - 1].normal0, seg_id);
 
@@ -289,6 +318,7 @@ RT_ResourceHandle RT_UploadLevelGeometry()
 		// NOTE(daniel): This is a separate call, because I don't want to do something tweaky like
 		// detecting whether tangents need to be calculated in RT_UploadMesh. You, the uploader, should know.
 		RT_GenerateTangents(triangles, num_triangles);
+		RT_GenerateTangents(portal_triangles, num_portal_triangles);
 
 		RT_UploadMeshParams params =
 		{
@@ -297,14 +327,24 @@ RT_ResourceHandle RT_UploadLevelGeometry()
 		};
 
 		RT_LOGF(RT_LOGSERVERITY_INFO, "UPLOADING MESH >>\n");
-		level_handle = RT_UploadMesh(&params);
+		*level_handle = RT_UploadMesh(&params);
+		RT_LOGF(RT_LOGSERVERITY_INFO, "UPLOADING MESH OK\n");
+
+		RT_UploadMeshParams params_portals =
+		{
+			.triangle_count = num_portal_triangles,
+			.triangles = portal_triangles,
+		};
+
+		RT_LOGF(RT_LOGSERVERITY_INFO, "UPLOADING MESH >>\n");
+		*portals_handle = RT_UploadMesh(&params_portals);
 		RT_LOGF(RT_LOGSERVERITY_INFO, "UPLOADING MESH OK\n");
 
 		// load and unload materials based on if they are needed for this level.
 		RT_SyncMaterialStates();
 	}
 
-	return level_handle;
+	return true;
 }
 
 bool RT_UnloadLevel()
@@ -321,6 +361,15 @@ bool RT_UnloadLevel()
 		return true;
 	}
 
+	// now unload the version with portals
+	if (RT_RESOURCE_HANDLE_VALID(g_level_with_portals_resource))
+	{
+		RT_ReleaseMesh(g_level_with_portals_resource);
+		g_level_with_portals_resource = RT_RESOURCE_HANDLE_NULL;
+
+		return true;
+	}
+
 	return false;
 }
 
@@ -331,11 +380,11 @@ bool RT_LoadLevel()
 	{
 		assert(!RT_RESOURCE_HANDLE_VALID(g_level_resource));
 		// Load level geometry
-		g_level_resource = RT_UploadLevelGeometry();
+		RT_UploadLevelGeometry(&g_level_resource, &g_level_with_portals_resource);
 		RT_ResetLightEmission();		// added this here as resetting light emission was getting skipped when doing a level warp
 		g_active_level = Current_level_num;
 
-		return RT_RESOURCE_HANDLE_VALID(g_level_resource);
+		return RT_RESOURCE_HANDLE_VALID(g_level_resource) && RT_RESOURCE_HANDLE_VALID(g_level_with_portals_resource);
 	}
 
 	return false;
@@ -350,7 +399,13 @@ void RT_RenderLevel(RT_Vec3 player_pos)
 	RT_FindAndSubmitNearbyLights(player_pos);
 
 	RT_Mat4 mat = RT_Mat4Identity();
-	RT_RaytraceMesh(g_level_resource, &mat, &mat);
+	
+	// switch which level to render if we are retracing rays or not
+	if(RT_GetRetraceRays())
+		RT_RaytraceMesh(g_level_with_portals_resource, &mat, &mat);
+	else
+		RT_RaytraceMesh(g_level_resource, &mat, &mat);
+	
 }
 
 void TraverseSegmentsForLights(short seg_num, uint8_t* visit_list, uint8_t* lights_added, int curr_rec_depth, RT_Vec3 curr_seg_entry_pos, float curr_segment_distance) {

--- a/RT/Game/level.c
+++ b/RT/Game/level.c
@@ -36,7 +36,7 @@ short m_lights_relevance_score[1024] = { 0.0f };
 short m_lights_to_sort[1024];
 int m_lights_found = 0;
 
-RT_Triangle RT_TriangleFromIndices(RT_Vertex* verts, int vert_offset, int v0, int v1, int v2, int tmap) 
+RT_Triangle RT_TriangleFromIndices(RT_Vertex* verts, int vert_offset, int v0, int v1, int v2, int tmap, bool portal, int segment, int segment_adjacent)
 {
 	RT_Triangle triangle = { 0 };
 
@@ -61,6 +61,10 @@ RT_Triangle RT_TriangleFromIndices(RT_Vertex* verts, int vert_offset, int v0, in
 	triangle.uv1 = verts[vert_offset + v1].uv;
 	triangle.uv2 = verts[vert_offset + v2].uv;
 	triangle.color = 0xFFFFFFFF;
+
+	triangle.portal = portal;
+	triangle.segment = segment;
+	triangle.segment_adjacent = segment_adjacent;
 
 	return triangle;
 }
@@ -184,6 +188,7 @@ RT_ResourceHandle RT_UploadLevelGeometry()
 					//assert(vert.uv.x >= -10.0 && vert.uv.x <= 10.0);
 				}
 
+				
 				// Ignore invisible walls
 				bool should_render = false;
 				if (seg->children[side_index] == -1)
@@ -199,22 +204,20 @@ RT_ResourceHandle RT_UploadLevelGeometry()
 						should_render = true;
 					}
 				}
-
-				if (!should_render) { continue; }
-
+				
 				int absolute_side_index = MAX_SIDES_PER_SEGMENT*seg_id + side_index;
 				switch (s->type) 
 				{
 					case SIDE_IS_TRI_13:
-						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 1, 3, absolute_side_index);
-						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 1, 2, 3, absolute_side_index);
+						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 1, 3, absolute_side_index, !should_render,seg_id, seg->children[side_index]);
+						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 1, 2, 3, absolute_side_index, !should_render, seg_id, seg->children[side_index]);
 					break;
 					
 					case SIDE_IS_QUAD:
 					case SIDE_IS_TRI_02:
 					default:
-						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 1, 2, absolute_side_index);
-						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 2, 3, absolute_side_index);
+						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 1, 2, absolute_side_index, !should_render, seg_id, seg->children[side_index]);
+						triangles[num_triangles++] = RT_TriangleFromIndices(verts, vertex_offset, 0, 2, 3, absolute_side_index, !should_render, seg_id, seg->children[side_index]);
 					break;
 				}
 				

--- a/RT/Game/level.c
+++ b/RT/Game/level.c
@@ -189,7 +189,7 @@ RT_ResourceHandle RT_UploadLevelGeometry()
 				}
 
 				
-				// Ignore invisible walls
+				// Mark invisible walls as portals
 				bool should_render = false;
 				if (seg->children[side_index] == -1)
 				{

--- a/RT/RTgr.c
+++ b/RT/RTgr.c
@@ -524,6 +524,10 @@ void RT_VertexFixToFloat_Fan(RT_TriangleBuffer *buf, int nv, g3s_point** pointli
 
     first_triangle.material_edge_index = texture_id;
 
+	first_triangle.portal = false;
+	first_triangle.segment = -1;
+	first_triangle.segment_adjacent = -1;
+
 	int start_count = buf->count;
 
 	for (int point_index = 1; point_index + 1 < nv; point_index++)
@@ -545,6 +549,10 @@ void RT_VertexFixToFloat_Fan(RT_TriangleBuffer *buf, int nv, g3s_point** pointli
 		triangle.uv2.y = f2fl(pointlist[point_index + 1]->p3_v);
 
         triangle.material_edge_index = texture_id;
+
+		triangle.portal = false;
+		triangle.segment = -1;
+		triangle.segment_adjacent = -1;
 		
 		//Now do the normals
 		RT_Vec3 p10 = RT_Vec3Normalize(RT_Vec3Sub(triangle.pos1, triangle.pos0));

--- a/RT/Renderer/Backend/Common/include/Renderer.h
+++ b/RT/Renderer/Backend/Common/include/Renderer.h
@@ -285,6 +285,7 @@ typedef struct RT_SceneSettings
 	uint32_t render_height_override;
 	bool render_blit;
 	int32_t render_segment;
+	bool external;
 } RT_SceneSettings;
 
 typedef struct RT_RasterTrianglesParams

--- a/RT/Renderer/Backend/Common/include/Renderer.h
+++ b/RT/Renderer/Backend/Common/include/Renderer.h
@@ -386,6 +386,7 @@ RT_API void RT_RenderImGui();
 // Utility functions
 
 RT_API void RT_QueueScreenshot(const char *file_name);
+RT_API bool RT_GetRetraceRays();
 
 // Don't forget to pop.
 #pragma pack(pop)

--- a/RT/Renderer/Backend/Common/include/Renderer.h
+++ b/RT/Renderer/Backend/Common/include/Renderer.h
@@ -209,6 +209,9 @@ typedef struct RT_Triangle
 	bool portal;				// is this triangle a portal to another segment
 	int32_t segment;			// what segment does this triangle belong too (if world geo)
 	int32_t segment_adjacent;	// if this is a portal what segment does it lead to
+
+	// terrain
+	bool terrain;				// is this triangle a terrain triangle
 } RT_Triangle;
 
 typedef struct RT_UploadMeshParams

--- a/RT/Renderer/Backend/Common/include/Renderer.h
+++ b/RT/Renderer/Backend/Common/include/Renderer.h
@@ -204,6 +204,11 @@ typedef struct RT_Triangle
 
 	uint32_t color;
 	uint32_t material_edge_index;
+	
+	// level geometry
+	bool portal;				// is this triangle a portal to another segment
+	int32_t segment;			// what segment does this triangle belong too (if world geo)
+	int32_t segment_adjacent;	// if this is a portal what segment does it lead to
 } RT_Triangle;
 
 typedef struct RT_UploadMeshParams
@@ -276,6 +281,7 @@ typedef struct RT_SceneSettings
 	uint32_t render_width_override;
 	uint32_t render_height_override;
 	bool render_blit;
+	int32_t render_segment;
 } RT_SceneSettings;
 
 typedef struct RT_RasterTrianglesParams

--- a/RT/Renderer/Backend/DX12/assets/shaders/direct_lighting.hlsli
+++ b/RT/Renderer/Backend/DX12/assets/shaders/direct_lighting.hlsli
@@ -243,10 +243,8 @@ void CalculateDirectLightingAtSurface(in HitGeometry IN, inout DirectLightingOut
 				occlusion_payload.visible = false;
 				occlusion_payload.num_portal_hits = 0;
 				occlusion_payload.start_segment = IN.hit_triangle.segment;
-				//occlusion_payload.portal_hits[0].segment = IN.hit_triangle.segment;	// put starting surface segment as first portal hit
-				//occlusion_payload.portal_hits[0].segment_adjacent = -1;
-				//occlusion_payload.portal_hits[0].hit_distance = 0.0;
 				occlusion_payload.valid_hit = false;
+				occlusion_payload.invalid_primitive_hit = -1;
 				
 				int count = 0;
 
@@ -257,7 +255,7 @@ void CalculateDirectLightingAtSurface(in HitGeometry IN, inout DirectLightingOut
 					if (!occlusion_payload.valid_hit)
 					{
 						// we finished, but the result wasn't valid (usually intersecting sector hit).  update ray to set min dist after the invalid hit and send again
-						occlusion_ray.TMin = occlusion_payload.hit_distance + 0.01; // offset to avoid re-intersect
+						occlusion_ray.TMin = occlusion_payload.hit_distance - 0.01; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
 					}
 
 					count++;

--- a/RT/Renderer/Backend/DX12/assets/shaders/direct_lighting.hlsli
+++ b/RT/Renderer/Backend/DX12/assets/shaders/direct_lighting.hlsli
@@ -241,10 +241,11 @@ void CalculateDirectLightingAtSurface(in HitGeometry IN, inout DirectLightingOut
 
 				OcclusionRayPayload occlusion_payload;
 				occlusion_payload.visible = false;
-				occlusion_payload.num_portal_hits = 1;
-				occlusion_payload.portal_hits[0].segment = IN.hit_triangle.segment;	// put starting surface segment as first portal hit
-				occlusion_payload.portal_hits[0].segment_adjacent = -1;
-				occlusion_payload.portal_hits[0].hit_distance = 0.0;
+				occlusion_payload.num_portal_hits = 0;
+				occlusion_payload.start_segment = IN.hit_triangle.segment;
+				//occlusion_payload.portal_hits[0].segment = IN.hit_triangle.segment;	// put starting surface segment as first portal hit
+				//occlusion_payload.portal_hits[0].segment_adjacent = -1;
+				//occlusion_payload.portal_hits[0].hit_distance = 0.0;
 				occlusion_payload.valid_hit = false;
 				
 				int count = 0;

--- a/RT/Renderer/Backend/DX12/assets/shaders/direct_lighting.hlsli
+++ b/RT/Renderer/Backend/DX12/assets/shaders/direct_lighting.hlsli
@@ -255,7 +255,7 @@ void CalculateDirectLightingAtSurface(in HitGeometry IN, inout DirectLightingOut
 					if (!occlusion_payload.valid_hit)
 					{
 						// we finished, but the result wasn't valid (usually intersecting sector hit).  update ray to set min dist after the invalid hit and send again
-						occlusion_ray.TMin = occlusion_payload.hit_distance - 0.01; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
+						occlusion_ray.TMin = occlusion_payload.hit_distance - 0.001; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
 					}
 
 					count++;

--- a/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
@@ -106,6 +106,11 @@ struct RT_Triangle
 
 	uint color;
 	uint material_edge_index;
+
+	// level geometry
+	bool portal;				// is this triangle a portal to another segment
+	int segment;			// what segment does this triangle belong too (if world geo)
+	int segment_adjacent;	// if this is a portal what segment does it lead to
 };
 
 // @Volatile: Must match RT_MaterialFlags in Renderer.h
@@ -130,6 +135,14 @@ struct RT_Light
 	uint     spot_vignette : 8;
 	uint     emission;
 	float3x4 transform;
+};
+
+// Common Structs
+struct PortalHit
+{
+	int segment;
+	int segment_adjacent;
+	float hit_distance;
 };
 
 // ------------------------------------------------------------------
@@ -1029,5 +1042,6 @@ float4 SampleTextureAnisotropic(Texture2D tex, SamplerState samp, float2 tex_gra
 
 	return tex.SampleGrad(samp, uv, tex_gradient1, tex_gradient2);
 }
+
 
 #endif /* COMMON_HLSL */

--- a/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
@@ -85,6 +85,8 @@ static const float PI = 3.14159265359;
 #define RT_RAY_T_MIN 0.001
 #define RT_RAY_T_MAX 10000
 
+#define RT_NUM_PORTAL_HITS 16
+
 // @Volatile: Must match RT_Triangle in Renderer.h
 struct RT_Triangle
 {

--- a/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
@@ -113,6 +113,9 @@ struct RT_Triangle
 	bool portal;				// is this triangle a portal to another segment
 	int segment;			// what segment does this triangle belong too (if world geo)
 	int segment_adjacent;	// if this is a portal what segment does it lead to
+
+	// terrain
+	bool terrain;				// is this triangle a terrain triangle
 };
 
 // @Volatile: Must match RT_MaterialFlags in Renderer.h

--- a/RT/Renderer/Backend/DX12/assets/shaders/include_shared/shared_common.hlsl.h
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include_shared/shared_common.hlsl.h
@@ -92,6 +92,9 @@ struct GlobalConstantBuffer
 
 	// Viewport offset, effectively offsets the center of the viewport after projecting
 	float    viewport_offset_y;
+
+	// What segment/cube is viewer in
+	int ray_segment;
 };
 
 struct GenMipMapSettings

--- a/RT/Renderer/Backend/DX12/assets/shaders/include_shared/shared_common.hlsl.h
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include_shared/shared_common.hlsl.h
@@ -95,6 +95,7 @@ struct GlobalConstantBuffer
 
 	// What segment/cube is viewer in
 	int ray_segment;
+	bool external;
 };
 
 struct GenMipMapSettings

--- a/RT/Renderer/Backend/DX12/assets/shaders/include_shared/shared_tweakvars.hlsl.h
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include_shared/shared_tweakvars.hlsl.h
@@ -46,6 +46,7 @@ TWEAK_BOOL   ("Override Materials",        override_materials,        false)
 TWEAK_FLOAT  ("Override Metallic",         override_metallic,         0,        0,    1)
 TWEAK_FLOAT  ("Override Roughness",        override_roughness,        0.3,      0,    1)
 TWEAK_BOOL   ("Enable Parallax Mapping",   enable_parallax_mapping,   true)
+TWEAK_BOOL   ("Retrace Rays",			   retrace_rays,			  true)
 // ------------------------------------------------------------------------------------------------------------------
 TWEAK_CATEGORY_END()
 

--- a/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting.hlsl
@@ -164,6 +164,7 @@ void IndirectLightingRaygen()
 
 			// Set up geometry input for primary ray trace
 			PrimaryRayPayload ray_payload = (PrimaryRayPayload)0;
+			
 			RayDesc ray   = (RayDesc)0;
 			ray.Origin    = gbuf_world_p + 0.01f * gbuf_normal;
 			ray.Direction = bounce_direction;

--- a/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting.hlsl
@@ -180,7 +180,7 @@ void IndirectLightingRaygen()
 			// Get geometry data from primary ray trace
 			GetHitGeometryFromRay(ray,
 				ray_payload.instance_idx, ray_payload.primitive_idx, ray_payload.barycentrics, ray_payload.hit_distance,
-				0, dispatch_idx, dispatch_dim, geo
+				0, dispatch_idx, dispatch_dim, geo, false
 			);
 			geo.world_p = gbuf_world_p + ray_payload.hit_distance * bounce_direction;
 

--- a/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting.hlsl
@@ -164,6 +164,10 @@ void IndirectLightingRaygen()
 
 			// Set up geometry input for primary ray trace
 			PrimaryRayPayload ray_payload = (PrimaryRayPayload)0;
+			ray_payload.num_portal_hits = 0;
+			ray_payload.start_segment = hit_triangle.segment;
+			ray_payload.invalid_primitive_hit = -1;
+			ray_payload.valid_hit = false;
 			
 			RayDesc ray   = (RayDesc)0;
 			ray.Origin    = gbuf_world_p + 0.01f * gbuf_normal;

--- a/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting_inline.hlsl
@@ -185,7 +185,7 @@ void IndirectLightingInline(COMPUTE_ARGS)
 				if (!ray_payload.valid_hit)
 				{
 					// we finished, but the result wasn't valid (usually intersecting sector hit).  update ray to set min dist after the invalid hit and send again
-					ray.TMin = ray_payload.hit_distance - 0.01; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
+					ray.TMin = ray_payload.hit_distance - 0.001; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
 				}
 
 				count++;

--- a/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting_inline.hlsl
@@ -184,7 +184,7 @@ void IndirectLightingInline(COMPUTE_ARGS)
 
 				if (!ray_payload.valid_hit)
 				{
-					// we finished, but the result wasn't valid (usually intersecting sector hit).  update ray to set min dist after the invalid hit and send again
+					// we finished, but the result wasn't valid (usually intersecting sector hit).  update ray to set min dist
 					ray.TMin = ray_payload.hit_distance - 0.001; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
 				}
 

--- a/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting_inline.hlsl
@@ -164,10 +164,11 @@ void IndirectLightingInline(COMPUTE_ARGS)
 
 			// Set up geometry input for primary ray trace
 			PrimaryRayPayload ray_payload = (PrimaryRayPayload)0;
-			ray_payload.num_portal_hits = 1;
-			ray_payload.portal_hits[0].segment = hit_triangle.segment;	// put starting segment as first portal hit
-			ray_payload.portal_hits[0].segment_adjacent = -1;	// not an actual portal, so it doesn't have an adjacent
-			ray_payload.portal_hits[0].hit_distance = 0.0;
+			ray_payload.num_portal_hits = 0;
+			ray_payload.start_segment = hit_triangle.segment;
+			//ray_payload.portal_hits[0].segment = hit_triangle.segment;	// put starting segment as first portal hit
+			//ray_payload.portal_hits[0].segment_adjacent = -1;	// not an actual portal, so it doesn't have an adjacent
+			//ray_payload.portal_hits[0].hit_distance = 0.0;
 			ray_payload.valid_hit = false;
 
 			RayDesc ray   = (RayDesc)0;

--- a/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting_inline.hlsl
@@ -178,17 +178,24 @@ void IndirectLightingInline(COMPUTE_ARGS)
 			// Trace the primary ray
 			int count = 0;
 
-			while (!ray_payload.valid_hit && count < 3)
+			if(tweak.retrace_rays)
+			{ 
+				while (!ray_payload.valid_hit && count < 3)
+				{
+					TracePrimaryRay(ray, ray_payload, pixel_pos);
+
+					if (!ray_payload.valid_hit)
+					{
+						// we finished, but the result wasn't valid (usually intersecting sector hit).  update ray to set min dist
+						ray.TMin = ray_payload.hit_distance - 0.001; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
+					}
+
+					count++;
+				}
+			}
+			else
 			{
 				TracePrimaryRay(ray, ray_payload, pixel_pos);
-
-				if (!ray_payload.valid_hit)
-				{
-					// we finished, but the result wasn't valid (usually intersecting sector hit).  update ray to set min dist
-					ray.TMin = ray_payload.hit_distance - 0.001; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
-				}
-
-				count++;
 			}
 
 			// Set up geometry output from primary ray trace and set non-zero defaults where necessary

--- a/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting_inline.hlsl
@@ -197,7 +197,7 @@ void IndirectLightingInline(COMPUTE_ARGS)
 			// Get geometry data from primary ray trace
 			GetHitGeometryFromRay(ray,
 				ray_payload.instance_idx, ray_payload.primitive_idx, ray_payload.barycentrics, ray_payload.hit_distance,
-				0, pixel_pos, g_global_cb.render_dim, geo
+				0, pixel_pos, g_global_cb.render_dim, geo, false
 			);
 			geo.world_p = gbuf_world_p + ray_payload.hit_distance*bounce_direction;
 

--- a/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/indirect_lighting_inline.hlsl
@@ -166,10 +166,8 @@ void IndirectLightingInline(COMPUTE_ARGS)
 			PrimaryRayPayload ray_payload = (PrimaryRayPayload)0;
 			ray_payload.num_portal_hits = 0;
 			ray_payload.start_segment = hit_triangle.segment;
-			//ray_payload.portal_hits[0].segment = hit_triangle.segment;	// put starting segment as first portal hit
-			//ray_payload.portal_hits[0].segment_adjacent = -1;	// not an actual portal, so it doesn't have an adjacent
-			//ray_payload.portal_hits[0].hit_distance = 0.0;
 			ray_payload.valid_hit = false;
+			ray_payload.invalid_primitive_hit = -1;
 
 			RayDesc ray   = (RayDesc)0;
 			ray.Origin    = gbuf_world_p + 0.01f * gbuf_normal;
@@ -187,7 +185,7 @@ void IndirectLightingInline(COMPUTE_ARGS)
 				if (!ray_payload.valid_hit)
 				{
 					// we finished, but the result wasn't valid (usually intersecting sector hit).  update ray to set min dist after the invalid hit and send again
-					ray.TMin = ray_payload.hit_distance + 0.01; // offset to avoid re-intersect
+					ray.TMin = ray_payload.hit_distance - 0.01; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
 				}
 
 				count++;

--- a/RT/Renderer/Backend/DX12/assets/shaders/occlusion.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/occlusion.hlsl
@@ -3,6 +3,10 @@
 struct OcclusionRayPayload
 {
 	bool visible;
+	float hit_distance;
+	int num_portal_hits;
+	PortalHit portal_hits[128];
+	bool valid_hit;
 };
 
 void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pixel_pos)
@@ -28,6 +32,28 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 		{
 			case CANDIDATE_NON_OPAQUE_TRIANGLE:
 			{
+				uint instance_idx = ray_query.CandidateInstanceIndex();
+				uint primitive_idx = ray_query.CandidatePrimitiveIndex();
+
+				InstanceData instance_data = g_instance_data_buffer[instance_idx];
+				RT_Triangle hit_triangle = GetHitTriangle(instance_data.triangle_buffer_idx, primitive_idx);
+				float hit_distance = ray_query.CandidateTriangleRayT();
+
+				// if triangle is portal add to list of portal hits (only do on first pass, we reuse the portal hit data in the event of a second pass.)
+				if (hit_triangle.portal)
+				{
+					
+					if (payload.num_portal_hits < 127)
+					{
+						payload.num_portal_hits++;
+						payload.portal_hits[payload.num_portal_hits - 1].segment = hit_triangle.segment;
+						payload.portal_hits[payload.num_portal_hits - 1].segment_adjacent = hit_triangle.segment_adjacent;
+						payload.portal_hits[payload.num_portal_hits - 1].hit_distance = hit_distance;
+					}
+					
+					break;  // never commit portal hits
+				}
+
 				Material hit_material;
 
 				if (!IsHitTransparent(
@@ -40,6 +66,20 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 				{
 					ray_query.CommitNonOpaqueTriangleHit();
 				}
+				else
+				{
+					// count a transparent wall as a portal
+					if (hit_triangle.segment != -1)
+					{
+						if (payload.num_portal_hits < 127)
+						{
+							payload.num_portal_hits++;
+							payload.portal_hits[payload.num_portal_hits].segment = hit_triangle.segment;
+							payload.portal_hits[payload.num_portal_hits].segment_adjacent = hit_triangle.segment_adjacent;
+							payload.portal_hits[payload.num_portal_hits].hit_distance = hit_distance;
+						}
+					}
+				}
 				break;
 			}
 		}
@@ -47,6 +87,68 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 
 	switch (ray_query.CommittedStatus())
 	{
+	case COMMITTED_TRIANGLE_HIT:
+	{
+		float hit_distance = ray_query.CommittedRayT();
+
+		uint instance_idx = ray_query.CommittedInstanceIndex();
+		uint primitive_idx = ray_query.CommittedPrimitiveIndex();
+
+		InstanceData instance_data = g_instance_data_buffer[instance_idx];
+		RT_Triangle hit_triangle = GetHitTriangle(instance_data.triangle_buffer_idx, primitive_idx);
+		payload.valid_hit = true;
+		payload.visible = true;
+
+		// if hit triangle is world geo (belongs to a segment) check the portal hits to see if its segment was the last portal we passed through before getting to it.  otherwise hit is invalid
+		if (hit_triangle.segment != -1)
+		{
+			bool valid_hit = false;
+			int search_segment = hit_triangle.segment;
+			uint retrace_count = 0;
+
+			while (retrace_count < 2) // retracing back through 2 portals seems to be enough to rid most artifacts
+			{
+				retrace_count++;
+
+				// check if we have gotten back to the rays origin segment
+				if (search_segment == payload.portal_hits[0].segment)
+				{
+					// we got back to origin, so hit is valid
+					break;
+				}
+
+				bool found = false;
+
+				// search the portal hits to see if we crossed a portal to get to the current search segment
+				for (int search_index = 0; search_index < 127; search_index++)
+				{
+					if (payload.portal_hits[search_index].segment_adjacent == search_segment)
+					{
+						found = true;
+						search_segment = payload.portal_hits[search_index].segment; // we'll continue the retrace with this segment on the next loop 
+						break;
+					}
+				}
+
+				if (!found)
+				{
+					// we hit geometry that we didn't cross a portal for.
+					payload.valid_hit = false;
+					break;
+				}
+
+			}
+		}
+
+		if (payload.valid_hit)
+		{
+			
+			payload.visible = false;
+		}
+		payload.hit_distance = hit_distance;
+
+		break;
+	}
 		case COMMITTED_NOTHING:
 		{
 			payload.visible = true;

--- a/RT/Renderer/Backend/DX12/assets/shaders/occlusion.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/occlusion.hlsl
@@ -5,7 +5,8 @@ struct OcclusionRayPayload
 	bool visible;
 	float hit_distance;
 	int num_portal_hits;
-	PortalHit portal_hits[128];
+	int start_segment;
+	PortalHit portal_hits[12];
 	bool valid_hit;
 };
 
@@ -42,14 +43,21 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 				// if triangle is portal add to list of portal hits (only do on first pass, we reuse the portal hit data in the event of a second pass.)
 				if (hit_triangle.portal)
 				{
+					payload.num_portal_hits++;
+
+					int portal_hit_index = payload.num_portal_hits % 12;
+
+					payload.portal_hits[portal_hit_index].segment = hit_triangle.segment;
+					payload.portal_hits[portal_hit_index].segment_adjacent = hit_triangle.segment_adjacent;
+					payload.portal_hits[portal_hit_index].hit_distance = hit_distance;
 					
-					if (payload.num_portal_hits < 127)
+					/*if (payload.num_portal_hits < 127)
 					{
 						payload.num_portal_hits++;
 						payload.portal_hits[payload.num_portal_hits - 1].segment = hit_triangle.segment;
 						payload.portal_hits[payload.num_portal_hits - 1].segment_adjacent = hit_triangle.segment_adjacent;
 						payload.portal_hits[payload.num_portal_hits - 1].hit_distance = hit_distance;
-					}
+					}*/
 					
 					break;  // never commit portal hits
 				}
@@ -71,13 +79,21 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 					// count a transparent wall as a portal
 					if (hit_triangle.segment != -1)
 					{
-						if (payload.num_portal_hits < 127)
+						payload.num_portal_hits++;
+
+						int portal_hit_index = payload.num_portal_hits % 12;
+
+						payload.portal_hits[portal_hit_index].segment = hit_triangle.segment;
+						payload.portal_hits[portal_hit_index].segment_adjacent = hit_triangle.segment_adjacent;
+						payload.portal_hits[portal_hit_index].hit_distance = hit_distance;
+
+						/*if (payload.num_portal_hits < 127)
 						{
 							payload.num_portal_hits++;
 							payload.portal_hits[payload.num_portal_hits].segment = hit_triangle.segment;
 							payload.portal_hits[payload.num_portal_hits].segment_adjacent = hit_triangle.segment_adjacent;
 							payload.portal_hits[payload.num_portal_hits].hit_distance = hit_distance;
-						}
+						}*/
 					}
 				}
 				break;
@@ -111,7 +127,7 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 				retrace_count++;
 
 				// check if we have gotten back to the rays origin segment
-				if (search_segment == payload.portal_hits[0].segment)
+				if (search_segment == payload.start_segment)
 				{
 					// we got back to origin, so hit is valid
 					break;
@@ -120,7 +136,7 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 				bool found = false;
 
 				// search the portal hits to see if we crossed a portal to get to the current search segment
-				for (int search_index = 0; search_index < 127; search_index++)
+				for (int search_index = 0; search_index < 12; search_index++)
 				{
 					if (payload.portal_hits[search_index].segment_adjacent == search_segment)
 					{

--- a/RT/Renderer/Backend/DX12/assets/shaders/occlusion.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/occlusion.hlsl
@@ -102,7 +102,7 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 		InstanceData instance_data = g_instance_data_buffer[instance_idx];
 		RT_Triangle hit_triangle = GetHitTriangle(instance_data.triangle_buffer_idx, primitive_idx);
 		payload.valid_hit = true;
-		payload.visible = true;
+		payload.visible = false;
 
 		if (tweak.retrace_rays)
 		{

--- a/RT/Renderer/Backend/DX12/assets/shaders/occlusion.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/occlusion.hlsl
@@ -4,10 +4,10 @@ struct OcclusionRayPayload
 {
 	bool visible;
 	float hit_distance;
-	int num_portal_hits;
 	int start_segment;
-	PortalHit portal_hits[12];
-	bool valid_hit;
+	int num_portal_hits;					// how many portals has ray crossed
+	PortalHit portal_hits[12];				// list of last 12 portals crossed 
+	bool valid_hit;							// Used to control if a ray needs to be retried due to hitting overlapping segment geometry
 	int invalid_primitive_hit;              // what invalid primitive id was hit (so we can ignore it when we try again)
 };
 
@@ -113,9 +113,9 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 		{
 			if (payload.portal_hits[search_index].segment_adjacent == search_segment)
 			{
-				//found = true;
+				// found the ray crossed a portal into this segment
 				hit_score += 10;
-				search_segment = payload.portal_hits[search_index].segment;
+				search_segment = payload.portal_hits[search_index].segment;		// update search segment for next loop
 				break;
 			}
 		}
@@ -124,53 +124,11 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 		{
 			if (payload.portal_hits[search_index].segment_adjacent == search_segment)
 			{
-				//found = true;
+				// found the ray crossed a portal into this segment
 				hit_score += 1;
-				search_segment = payload.portal_hits[search_index].segment;
 				break;
 			}
 		}
-
-		/*// if hit triangle is world geo (belongs to a segment) check the portal hits to see if its segment was the last portal we passed through before getting to it.  otherwise hit is invalid
-		if (hit_triangle.segment != -1)
-		{
-			bool valid_hit = false;
-			int search_segment = hit_triangle.segment;
-			uint retrace_count = 0;
-
-			while (retrace_count < 2) // retracing back through 2 portals seems to be enough to rid most artifacts
-			{
-				retrace_count++;
-
-				// check if we have gotten back to the rays origin segment
-				if (search_segment == payload.start_segment)
-				{
-					// we got back to origin, so hit is valid
-					break;
-				}
-
-				bool found = false;
-
-				// search the portal hits to see if we crossed a portal to get to the current search segment
-				for (int search_index = 0; search_index < 12; search_index++)
-				{
-					if (payload.portal_hits[search_index].segment_adjacent == search_segment)
-					{
-						found = true;
-						search_segment = payload.portal_hits[search_index].segment; // we'll continue the retrace with this segment on the next loop 
-						break;
-					}
-				}
-
-				if (!found)
-				{
-					// we hit geometry that we didn't cross a portal for.
-					payload.valid_hit = false;
-					break;
-				}
-
-			}
-		}*/
 
 		if (hit_score > 10)
 		{

--- a/RT/Renderer/Backend/DX12/assets/shaders/occlusion.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/occlusion.hlsl
@@ -104,7 +104,7 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 		payload.valid_hit = true;
 		payload.visible = false;
 
-		if (tweak.retrace_rays)
+		if (tweak.retrace_rays && payload.start_segment != -1)
 		{
 			int hit_score = 0;
 
@@ -142,6 +142,7 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 			else
 			{
 				payload.valid_hit = false;
+
 				payload.invalid_primitive_hit = primitive_idx;
 			}
 			
@@ -152,6 +153,7 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 	}
 		case COMMITTED_NOTHING:
 		{
+			payload.valid_hit = true;
 			payload.visible = true;
 			break;
 		}

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsl
@@ -50,7 +50,7 @@ void PrimaryRaygen()
     // Get geometry data from primary ray trace
     GetHitGeometryFromRay(ray,
         ray_payload.instance_idx, ray_payload.primitive_idx, ray_payload.barycentrics, ray_payload.hit_distance,
-        0, dispatch_idx, dispatch_dim, geo, true
+        0, dispatch_idx, dispatch_dim, geo, tweak.enable_parallax_mapping
     );
     float3 geo_world_p = ReconstructWorldPosition(g_global_cb.view_inv, ray.Direction, ray_payload.hit_distance);
 

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsl
@@ -50,7 +50,7 @@ void PrimaryRaygen()
     // Get geometry data from primary ray trace
     GetHitGeometryFromRay(ray,
         ray_payload.instance_idx, ray_payload.primitive_idx, ray_payload.barycentrics, ray_payload.hit_distance,
-        0, dispatch_idx, dispatch_dim, geo
+        0, dispatch_idx, dispatch_dim, geo, true
     );
     float3 geo_world_p = ReconstructWorldPosition(g_global_cb.view_inv, ray.Direction, ray_payload.hit_distance);
 

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
@@ -125,7 +125,7 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
                 uint retrace_count = 0;
 
                 
-                while (retrace_count < 2)  // retracing back through 2 portals seems to be enough to rid most artifacts
+                while (retrace_count < 2)  // retracing back through 2 portals seems to be enough to rid of most artifacts
                 {
                     retrace_count++;
 

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
@@ -214,6 +214,10 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
                 payload.hit_distance = hit_distance;
                 
             }
+
+            // we need the hit distance, as long as we didn't hit the terrain along the way
+            if(!payload.hit_terrain)        
+                payload.hit_distance = hit_distance;
             
 
             break;

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
@@ -9,11 +9,12 @@ struct PrimaryRayPayload
     uint primitive_idx;
     float2 barycentrics;
     float hit_distance;
-    int num_portal_hits;
-    int start_segment;
-    PortalHit portal_hits[12];       //  just track the last 4 hits
+    int start_segment;                  
+    int num_portal_hits;                    // how many portals has ray crossed
+    PortalHit portal_hits[12];              // list of last 12 portals crossed
+    bool valid_hit;                         // Used to control if a ray needs to be retried due to hitting overlapping segment geometry
     int invalid_primitive_hit;              // what invalid primitive id was hit (so we can ignore it when we try again)
-    bool valid_hit;
+
 };
 
 void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_pos)
@@ -129,7 +130,6 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
             {
                 if (payload.portal_hits[search_index].segment_adjacent == search_segment)
                 {
-                    //found = true;
                     hit_score += 10;
                     search_segment = payload.portal_hits[search_index].segment; 
                     break;
@@ -140,56 +140,11 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
             {
                 if (payload.portal_hits[search_index].segment_adjacent == search_segment)
                 {
-                    //found = true;
                     hit_score += 1;
                     search_segment = payload.portal_hits[search_index].segment;
                     break;
                 }
             }
-            
-            /*if (hit_triangle.segment != -1)
-            {
-                
-                bool valid_hit = false;
-                int search_segment = hit_triangle.segment;
-                uint retrace_count = 0;
-
-                
-                while (retrace_count < 2)  // retracing back through 2 portals seems to be enough to rid of most artifacts
-                {
-                    retrace_count++;
-
-                    // check if we have gotten back to the rays origin segment
-                    if (search_segment == payload.start_segment)
-                    {
-                        // we got back to origin, so hit is valid
-                        break;
-                    }
-
-                    bool found = false;
-
-                    // search the portal hits to see if we crossed a portal to get to the current search segment
-                    
-                    for (int search_index = 0; search_index < 12; search_index++)
-                    {
-                        if (payload.portal_hits[search_index].segment_adjacent == search_segment)
-                        {
-                            found = true;
-                            search_segment = payload.portal_hits[search_index].segment; // we'll continue the retrace with this segment on the next loop 
-                            break;
-                        }
-                    }
-
-                    if (!found)
-                    {
-                        // we hit geometry that we didn't cross a portal for.
-                        payload.valid_hit = false;
-                        break;
-                    }
-
-                }
-                
-            }*/
 
             if(hit_score > 10)
             {

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
@@ -58,16 +58,6 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
                     payload.portal_hits[portal_hit_index].segment = hit_triangle.segment;
                     payload.portal_hits[portal_hit_index].segment_adjacent = hit_triangle.segment_adjacent;
                     payload.portal_hits[portal_hit_index].hit_distance = hit_distance;
-
-                    
-                    /*if (payload.num_portal_hits < 127)
-                    {
-                        payload.num_portal_hits++;
-                        payload.portal_hits[payload.num_portal_hits - 1 ].segment = hit_triangle.segment;
-                        payload.portal_hits[payload.num_portal_hits - 1 ].segment_adjacent = hit_triangle.segment_adjacent;
-                        payload.portal_hits[payload.num_portal_hits - 1 ].hit_distance = hit_distance;
-                        
-                    }*/
                     
                     break;  // always don't commit portal hits
                 }
@@ -99,14 +89,6 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
                             payload.portal_hits[portal_hit_index].segment = hit_triangle.segment;
                             payload.portal_hits[portal_hit_index].segment_adjacent = hit_triangle.segment_adjacent;
                             payload.portal_hits[portal_hit_index].hit_distance = hit_distance;
-
-                            /*if (payload.num_portal_hits < 127)
-                            {
-                                payload.num_portal_hits++;
-                                payload.portal_hits[payload.num_portal_hits - 1 ].segment = hit_triangle.segment;
-                                payload.portal_hits[payload.num_portal_hits - 1 ].segment_adjacent = hit_triangle.segment_adjacent;
-                                payload.portal_hits[payload.num_portal_hits - 1 ].hit_distance = hit_distance;
-                            }*/
                         }
                     }
                 }

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
@@ -180,17 +180,17 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
                 {
                     bool is_geo = hit_triangle.segment != -1;
                     bool is_start = hit_triangle.segment == payload.start_segment; // triangle is in start segment (which is exit cube when external)
-                    bool ray_crossed_start_portal = false;
+                    bool ray_crossed_exit_portal = false;
                     for (int search_index = 0; search_index < RT_NUM_PORTAL_HITS; search_index++)
                     {
                         if (payload.portal_hits[search_index].segment == payload.start_segment)
                         {
-                            ray_crossed_start_portal = true;
+                            ray_crossed_exit_portal = true;
                             break;
                         }
                     }
 
-                    if (!is_geo || is_start || ray_crossed_start_portal)
+                    if (!is_geo || is_start || ray_crossed_exit_portal)
                     {
                         payload.valid_hit = true;
                         payload.instance_idx = instance_idx;
@@ -294,7 +294,7 @@ void GetHitGeometryFromRay(RayDesc ray,
         // ==========================================================================
         // parallax mapping
         // ==========================================================================
-        if (tweak.enable_parallax_mapping && do_parallax)
+        if (do_parallax)
         {
             Texture2D tex_height = GetTextureFromIndex(hit_material.height_index);
 

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
@@ -168,6 +168,7 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
                         payload.instance_idx = instance_idx;
                         payload.primitive_idx = primitive_idx;
                         payload.barycentrics = ray_query.CommittedTriangleBarycentrics();
+                        payload.hit_distance = hit_distance;
                     }
                     else
                     {
@@ -178,11 +179,11 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
                 else // external 
                 {
                     bool is_geo = hit_triangle.segment != -1;
-                    bool is_start = hit_triangle.segment == payload.start_segment; // triangle is in start segment
+                    bool is_start = hit_triangle.segment == payload.start_segment; // triangle is in start segment (which is exit cube when external)
                     bool ray_crossed_start_portal = false;
                     for (int search_index = 0; search_index < RT_NUM_PORTAL_HITS; search_index++)
                     {
-                        if (payload.portal_hits[search_index].segment_adjacent == payload.start_segment)
+                        if (payload.portal_hits[search_index].segment == payload.start_segment)
                         {
                             ray_crossed_start_portal = true;
                             break;
@@ -195,6 +196,7 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
                         payload.instance_idx = instance_idx;
                         payload.primitive_idx = primitive_idx;
                         payload.barycentrics = ray_query.CommittedTriangleBarycentrics();
+                        payload.hit_distance = hit_distance;
                     }
                     else
                     {
@@ -209,8 +211,10 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
                 payload.instance_idx = instance_idx;
                 payload.primitive_idx = primitive_idx;
                 payload.barycentrics = ray_query.CommittedTriangleBarycentrics();
+                payload.hit_distance = hit_distance;
+                
             }
-            payload.hit_distance = hit_distance;
+            
 
             break;
 		}

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
@@ -120,7 +120,7 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
             RT_Triangle hit_triangle = GetHitTriangle(instance_data.triangle_buffer_idx, primitive_idx);
             payload.valid_hit = true;
 
-            if (tweak.retrace_rays)
+            if (tweak.retrace_rays && payload.start_segment != -1)
             {
                 int hit_score = 0;
 

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
@@ -12,6 +12,7 @@ void PrimaryRayInline(COMPUTE_ARGS)
 
 	// Trace the primary ray
 	RayDesc ray = GetRayDesc(pixel_pos, g_global_cb.render_dim);
+	ray.TMin = 0.00000000;											// for primary ray this must be 0.0 for ray retrace to work. moving ray forward even a little bit can move it into a segment ship/camera is not in, resulting in retrace failing and level geo disappearing
 	PrimaryRayPayload ray_payload = (PrimaryRayPayload)0;
 	ray_payload.num_portal_hits = 0;
 	ray_payload.start_segment = g_global_cb.ray_segment;

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
@@ -13,10 +13,11 @@ void PrimaryRayInline(COMPUTE_ARGS)
 	// Trace the primary ray
 	RayDesc ray = GetRayDesc(pixel_pos, g_global_cb.render_dim);
 	PrimaryRayPayload ray_payload = (PrimaryRayPayload)0;
-	ray_payload.num_portal_hits = 1;
-	ray_payload.portal_hits[0].segment = g_global_cb.ray_segment;	// put starting segment as first portal hit
-	ray_payload.portal_hits[0].segment_adjacent = -1;	// not an actual portal, so it doesn't have an adjacent
-	ray_payload.portal_hits[0].hit_distance = 0.0;
+	ray_payload.num_portal_hits = 0;
+	ray_payload.start_segment = g_global_cb.ray_segment;
+	//ray_payload.portal_hits[0].segment = g_global_cb.ray_segment;	// put starting segment as first portal hit
+	//ray_payload.portal_hits[0].segment_adjacent = -1;	// not an actual portal, so it doesn't have an adjacent
+	//ray_payload.portal_hits[0].hit_distance = 0.0;
 	ray_payload.valid_hit = false;
 	
 	int count = 0;

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
@@ -50,7 +50,7 @@ void PrimaryRayInline(COMPUTE_ARGS)
 
 	GetHitGeometryFromRay(ray,
 		ray_payload.instance_idx, ray_payload.primitive_idx, ray_payload.barycentrics, ray_payload.hit_distance,
-		0, pixel_pos, g_global_cb.render_dim, geo, true
+		0, pixel_pos, g_global_cb.render_dim, geo, tweak.enable_parallax_mapping
 	);
 
 	// ---------------------------------------------------------------------------------------------------------------

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
@@ -43,7 +43,7 @@ void PrimaryRayInline(COMPUTE_ARGS)
 
 	GetHitGeometryFromRay(ray,
 		ray_payload.instance_idx, ray_payload.primitive_idx, ray_payload.barycentrics, ray_payload.hit_distance,
-		0, pixel_pos, g_global_cb.render_dim, geo
+		0, pixel_pos, g_global_cb.render_dim, geo, true
 	);
 
 	// ---------------------------------------------------------------------------------------------------------------

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
@@ -20,17 +20,24 @@ void PrimaryRayInline(COMPUTE_ARGS)
 	
 	int count = 0;
 
-	while (!ray_payload.valid_hit && count < 3)
+	if (tweak.retrace_rays)
+	{
+		while (!ray_payload.valid_hit && count < 3)
+		{
+			TracePrimaryRay(ray, ray_payload, pixel_pos);
+
+			if (!ray_payload.valid_hit)
+			{
+				// we finished, but the result wasn't valid (usually intersecting sector hit).  update ray to set min dist after the invalid hit and send again
+				ray.TMin = ray_payload.hit_distance - 0.001; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
+			}
+
+			count++;
+		}
+	}
+	else
 	{
 		TracePrimaryRay(ray, ray_payload, pixel_pos);
-
-		if (!ray_payload.valid_hit)
-		{
-			// we finished, but the result wasn't valid (usually intersecting sector hit).  update ray to set min dist after the invalid hit and send again
-			ray.TMin = ray_payload.hit_distance - 0.001; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
-		}
-
-		count++;
 	}
 
 	

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
@@ -27,7 +27,7 @@ void PrimaryRayInline(COMPUTE_ARGS)
 		if (!ray_payload.valid_hit)
 		{
 			// we finished, but the result wasn't valid (usually intersecting sector hit).  update ray to set min dist after the invalid hit and send again
-			ray.TMin = ray_payload.hit_distance - 0.01; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
+			ray.TMin = ray_payload.hit_distance - 0.001; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
 		}
 
 		count++;

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
@@ -15,9 +15,7 @@ void PrimaryRayInline(COMPUTE_ARGS)
 	PrimaryRayPayload ray_payload = (PrimaryRayPayload)0;
 	ray_payload.num_portal_hits = 0;
 	ray_payload.start_segment = g_global_cb.ray_segment;
-	//ray_payload.portal_hits[0].segment = g_global_cb.ray_segment;	// put starting segment as first portal hit
-	//ray_payload.portal_hits[0].segment_adjacent = -1;	// not an actual portal, so it doesn't have an adjacent
-	//ray_payload.portal_hits[0].hit_distance = 0.0;
+	ray_payload.invalid_primitive_hit = -1;
 	ray_payload.valid_hit = false;
 	
 	int count = 0;
@@ -29,7 +27,7 @@ void PrimaryRayInline(COMPUTE_ARGS)
 		if (!ray_payload.valid_hit)
 		{
 			// we finished, but the result wasn't valid (usually intersecting sector hit).  update ray to set min dist after the invalid hit and send again
-			ray.TMin = ray_payload.hit_distance + 0.01; // offset to avoid re-intersect
+			ray.TMin = ray_payload.hit_distance - 0.01; // retry ray just before the previous hit to handle retrying coplanar faces (which can happen with overlapping geo)
 		}
 
 		count++;

--- a/RT/Renderer/Backend/DX12/src/GLTFLoader.cpp
+++ b/RT/Renderer/Backend/DX12/src/GLTFLoader.cpp
@@ -316,6 +316,14 @@ RT_GLTFNode *RT_LoadGLTF(RT_Arena *arena, const char *path, RT_MaterialOverride*
 				prim_triangles[triangle_index].material_edge_index = material_index|RT_TRIANGLE_HOLDS_MATERIAL_INDEX;
 			}
 
+			// set the world geometry members
+			for (size_t triangle_index = 0; triangle_index < prim_triangle_count; triangle_index++)
+			{
+				prim_triangles[triangle_index].portal = false;
+				prim_triangles[triangle_index].segment = -1;
+				prim_triangles[triangle_index].segment_adjacent = -1;
+			}
+
 			size_t    index_count = primitive->indices->count;
 			uint32_t *indices     = nullptr;
 

--- a/RT/Renderer/Backend/DX12/src/GlobalDX.h
+++ b/RT/Renderer/Backend/DX12/src/GlobalDX.h
@@ -459,6 +459,8 @@ namespace RT
 			int freezeframe;
 			
 			bool render_blit;
+
+			int32_t render_segment;
 		} scene;
 
 		RingBuffer resource_upload_ring_buffer;

--- a/RT/Renderer/Backend/DX12/src/GlobalDX.h
+++ b/RT/Renderer/Backend/DX12/src/GlobalDX.h
@@ -461,6 +461,7 @@ namespace RT
 			bool render_blit;
 
 			int32_t render_segment;
+			bool external;			//are we outside the mine
 		} scene;
 
 		RingBuffer resource_upload_ring_buffer;

--- a/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
+++ b/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
@@ -2553,6 +2553,9 @@ void RenderBackend::Init(const RT_RendererInitParams* render_init_params)
 		triangles[0].uv2      = uvs[2];
 		triangles[0].color    = 0xFFFFFFFF;
 		triangles[0].material_edge_index = RT_TRIANGLE_MATERIAL_INSTANCE_OVERRIDE;
+		triangles[0].portal = false;
+		triangles[0].segment = -1;
+		triangles[0].segment_adjacent = -1;
 
 		triangles[1].pos0     = vertices[0];
 		triangles[1].pos1     = vertices[2];
@@ -2568,6 +2571,9 @@ void RenderBackend::Init(const RT_RendererInitParams* render_init_params)
 		triangles[1].uv2      = uvs[3];
 		triangles[1].color    = 0xFFFFFFFF;
 		triangles[1].material_edge_index = RT_TRIANGLE_MATERIAL_INSTANCE_OVERRIDE;
+		triangles[1].portal = false;
+		triangles[1].segment = -1;
+		triangles[1].segment_adjacent = -1;
 
 		RT_UploadMeshParams params = {};
 		params.name           = "Billboard Quad";
@@ -3080,6 +3086,8 @@ void RenderBackend::BeginScene(const RT_SceneSettings* scene_settings)
 	g_d3d.scene.freezeframe |= tweak_vars.freezeframe;
 	g_d3d.scene.prev_camera = g_d3d.scene.camera;
 
+	g_d3d.scene.render_segment = scene_settings->render_segment;
+
 	g_d3d.prev_lights_count = g_d3d.lights_count;
 
 	if (!g_d3d.scene.freezeframe)
@@ -3161,6 +3169,8 @@ void RenderBackend::EndScene()
 			scene_cb->viewport_offset_y = g_d3d.viewport_offset_y;
 			scene_cb->screen_color_overlay = g_d3d.io.screen_overlay_color;
 
+			scene_cb->ray_segment = g_d3d.scene.render_segment;
+			
 			D3D12_CPU_DESCRIPTOR_HANDLE cbv = frame->descriptors.GetCPUDescriptor(D3D12GlobalDescriptors_CBV_GlobalConstantBuffer);
 
 			D3D12_CONSTANT_BUFFER_VIEW_DESC cbv_desc = {};

--- a/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
+++ b/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
@@ -3087,6 +3087,7 @@ void RenderBackend::BeginScene(const RT_SceneSettings* scene_settings)
 	g_d3d.scene.prev_camera = g_d3d.scene.camera;
 
 	g_d3d.scene.render_segment = scene_settings->render_segment;
+	g_d3d.scene.external = scene_settings->external;
 
 	g_d3d.prev_lights_count = g_d3d.lights_count;
 
@@ -3170,6 +3171,7 @@ void RenderBackend::EndScene()
 			scene_cb->screen_color_overlay = g_d3d.io.screen_overlay_color;
 
 			scene_cb->ray_segment = g_d3d.scene.render_segment;
+			scene_cb->external = g_d3d.scene.external;
 			
 			D3D12_CPU_DESCRIPTOR_HANDLE cbv = frame->descriptors.GetCPUDescriptor(D3D12GlobalDescriptors_CBV_GlobalConstantBuffer);
 

--- a/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
+++ b/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
@@ -4602,6 +4602,11 @@ void RenderBackend::RaytraceSetSkyColors(const RT_Vec3 top, const RT_Vec3 bottom
 	CurrentFrameData()->scene_cb.As<GlobalConstantBuffer>()->sky_color_bottom = bottom;
 }
 
+bool RenderBackend::GetRetraceRays()
+{
+	return tweak_vars.retrace_rays;
+}
+
 void RenderBackend::RasterSetViewport(float x, float y, float width, float height)
 {
 	g_d3d_raster.viewport = { x, y, width, height, 0.1f, 5000.0f };

--- a/RT/Renderer/Backend/DX12/src/RenderBackend.h
+++ b/RT/Renderer/Backend/DX12/src/RenderBackend.h
@@ -47,6 +47,7 @@ namespace RenderBackend
 	void RaytraceRod(uint16_t material_index, RT_Vec3 bot_p, RT_Vec3 top_p, float width);
 	void RaytraceRender();
     void RaytraceSetSkyColors(RT_Vec3 top, RT_Vec3 bottom);
+	bool GetRetraceRays();
 
 	// -----------------------------------------------------------------------------------------------
 	// Rasterization (UI, debug rendering)

--- a/RT/Renderer/Backend/DX12/src/Renderer.cpp
+++ b/RT/Renderer/Backend/DX12/src/Renderer.cpp
@@ -353,3 +353,8 @@ void RT_QueueScreenshot(const char *file_name)
 {
 	RenderBackend::QueueScreenshot(file_name);
 }
+
+bool RT_GetRetraceRays()
+{
+	return RenderBackend::GetRetraceRays();
+}

--- a/d1/assets/render_presets/default.vars
+++ b/d1/assets/render_presets/default.vars
@@ -67,3 +67,4 @@ gamma = -0.300000
 bloom_amount = 0.025000
 exposure = 0.100000
 enable_parallax_mapping = 1
+retrace_rays = 1

--- a/d1/assets/render_presets/gamer.vars
+++ b/d1/assets/render_presets/gamer.vars
@@ -60,3 +60,4 @@ albedo_sample_linear = 0
 gamma = -0.300000
 bloom_amount = 0.150000
 enable_parallax_mapping = 1
+retrace_rays = 1

--- a/d1/main/endlevel.c
+++ b/d1/main/endlevel.c
@@ -920,6 +920,7 @@ void render_external_scene(fix eye_offset)
 	ogl_toggle_depth_test(0);
 	Render_depth = (200-(vm_vec_dist_quick(&mine_ground_exit_point, &Viewer_eye)/F1_0))/36;
 #endif
+	RT_RenderLevel(RT_Vec3Fromvms_vector(&Viewer->pos));
 	render_terrain(&mine_ground_exit_point,exit_point_bmx,exit_point_bmy);
 #ifdef OGL
 	Render_depth = orig_Render_depth;

--- a/d1/main/endlevel.c
+++ b/d1/main/endlevel.c
@@ -1077,6 +1077,7 @@ void render_endlevel_frame(fix eye_offset)
 		.camera = &camera,
 		.render_height_override = 0,
 		.render_width_override = 0,
+		.render_segment = Viewer->segnum,
 	};
 	RT_BeginScene(&frame_settings);
 	RT_RaytraceSetSkyColors(RT_Vec3Make(0.5, 0.5, 0.5), RT_Vec3Make(0.5, 0.5, 0.5));

--- a/d1/main/endlevel.c
+++ b/d1/main/endlevel.c
@@ -1073,18 +1073,33 @@ void render_endlevel_frame(fix eye_offset)
 		.near_plane = 0.1f,
 		.far_plane = 10000.0f
 	};
+	
+	bool not_outside = Endlevel_sequence < EL_OUTSIDE;
+	int32_t render_segment;
+
+	if (not_outside)
+	{
+		render_segment = Viewer->segnum;
+	}
+	else
+	{
+		render_segment = exit_segnum;
+	}
+
 	RT_SceneSettings frame_settings =
 	{
 		.camera = &camera,
 		.render_height_override = 0,
 		.render_width_override = 0,
-		.render_segment = Viewer->segnum,
+		.render_segment = render_segment,
+		.external = !not_outside,
+		
 	};
 	RT_BeginScene(&frame_settings);
 	RT_RaytraceSetSkyColors(RT_Vec3Make(0.5, 0.5, 0.5), RT_Vec3Make(0.5, 0.5, 0.5));
 #endif
 
-	if (Endlevel_sequence < EL_OUTSIDE)
+	if (not_outside)
 		endlevel_render_mine(eye_offset);
 	else
 		render_external_scene(eye_offset);

--- a/d1/main/endlevel.c
+++ b/d1/main/endlevel.c
@@ -920,7 +920,10 @@ void render_external_scene(fix eye_offset)
 	ogl_toggle_depth_test(0);
 	Render_depth = (200-(vm_vec_dist_quick(&mine_ground_exit_point, &Viewer_eye)/F1_0))/36;
 #endif
-	RT_RenderLevel(RT_Vec3Fromvms_vector(&Viewer->pos));
+	// only render level if retracing rays are enabled, otherwise whole level will appear on terrain and not just what should be seen through tunnel exit
+	if (RT_GetRetraceRays())
+		RT_RenderLevel(RT_Vec3Fromvms_vector(&Viewer->pos));
+
 	render_terrain(&mine_ground_exit_point,exit_point_bmx,exit_point_bmy);
 #ifdef OGL
 	Render_depth = orig_Render_depth;

--- a/d1/main/menu.c
+++ b/d1/main/menu.c
@@ -1462,6 +1462,9 @@ void raytrace_config()
 	int opt_gr_enable_parallax = nitems;
 	m[nitems].type = NM_TYPE_CHECK; m[nitems].text = "Parallax Mapping"; m[nitems].value = RT_GetIntFromConfig(config, RT_StringLiteral("enable_parallax_mapping")); nitems++;
 
+	int opt_gr_retrace_rays = nitems;
+	m[nitems].type = NM_TYPE_CHECK; m[nitems].text = "Retrace Rays"; m[nitems].value = RT_GetIntFromConfig(config, RT_StringLiteral("retrace_rays")); nitems++;
+
 	RT_ASSERT(nitems <= RT_ARRAY_COUNT(m));
 
 	newmenu_do1( NULL, "Raytracing Options", nitems, m, raytrace_config_menuset, NULL, 1 );
@@ -1551,6 +1554,7 @@ void raytrace_config()
 		RT_ConfigWriteFloat(config, RT_StringLiteral("vignette_strength"), ((float)m[opt_gr_vignette_strength].value)/10.0f);
 
 		RT_ConfigWriteInt(config, RT_StringLiteral("enable_parallax_mapping"), m[opt_gr_enable_parallax].value);
+		RT_ConfigWriteInt(config, RT_StringLiteral("retrace_rays"), m[opt_gr_retrace_rays].value);
 
 		RT_SerializeConfigToFile(config, RT_RENDER_SETTINGS_CONFIG_FILE); 
 		config->last_modified_time = RT_GetHighResTime().value;

--- a/d1/main/render.c
+++ b/d1/main/render.c
@@ -1623,6 +1623,7 @@ void render_frame(fix eye_offset)
 
 	scene_settings.render_width_override = Screen_3d_window.cv_bitmap.bm_w;
 	scene_settings.render_height_override = Screen_3d_window.cv_bitmap.bm_h;
+	scene_settings.render_segment = Viewer->segnum;
 	RT_BeginScene(&scene_settings);
 
 	// Player light

--- a/d1/main/render.c
+++ b/d1/main/render.c
@@ -1623,7 +1623,7 @@ void render_frame(fix eye_offset)
 
 	scene_settings.render_width_override = Screen_3d_window.cv_bitmap.bm_w;
 	scene_settings.render_height_override = Screen_3d_window.cv_bitmap.bm_h;
-	scene_settings.render_segment = Viewer->segnum;
+	scene_settings.render_segment = start_seg_num;
 	scene_settings.external = false;
 	RT_BeginScene(&scene_settings);
 

--- a/d1/main/render.c
+++ b/d1/main/render.c
@@ -1624,6 +1624,7 @@ void render_frame(fix eye_offset)
 	scene_settings.render_width_override = Screen_3d_window.cv_bitmap.bm_w;
 	scene_settings.render_height_override = Screen_3d_window.cv_bitmap.bm_h;
 	scene_settings.render_segment = Viewer->segnum;
+	scene_settings.external = false;
 	RT_BeginScene(&scene_settings);
 
 	// Player light

--- a/d1/main/terrain.c
+++ b/d1/main/terrain.c
@@ -489,6 +489,7 @@ void load_terrain(char *filename)
 				triangles[n_triangles].portal = false;
 				triangles[n_triangles].segment = -1;
 				triangles[n_triangles].segment_adjacent = -1;
+				triangles[n_triangles].terrain = true;
 
                 n_triangles++;
 
@@ -507,6 +508,7 @@ void load_terrain(char *filename)
 				triangles[n_triangles].portal = false;
 				triangles[n_triangles].segment = -1;
 				triangles[n_triangles].segment_adjacent = -1;
+				triangles[n_triangles].terrain = true;
                 n_triangles++;
             }
         }

--- a/d1/main/terrain.c
+++ b/d1/main/terrain.c
@@ -486,6 +486,10 @@ void load_terrain(char *filename)
                 triangles[n_triangles].normal2 = normal1;
                 triangles[n_triangles].color = 0xFFFFFFFF;
                 triangles[n_triangles].material_edge_index = RT_MATERIAL_ENDLEVEL_TERRAIN;
+				triangles[n_triangles].portal = false;
+				triangles[n_triangles].segment = -1;
+				triangles[n_triangles].segment_adjacent = -1;
+
                 n_triangles++;
 
                 // Create triangle 2
@@ -500,6 +504,9 @@ void load_terrain(char *filename)
                 triangles[n_triangles].normal2 = normal2;
 				triangles[n_triangles].color = 0xFFFFFFFF;
                 triangles[n_triangles].material_edge_index = RT_MATERIAL_ENDLEVEL_TERRAIN;
+				triangles[n_triangles].portal = false;
+				triangles[n_triangles].segment = -1;
+				triangles[n_triangles].segment_adjacent = -1;
                 n_triangles++;
             }
         }


### PR DESCRIPTION
Original game data has overlapping segments that often don't render correctly with new ray trace engine.

Re-add invisible walls as portal surfaces.  It then tracks when these portals are crossed in the ray payload.  Once ray hits a surface it verifies that it passed through at least two portals that lead to the surface, otherwise rejects the hit.  This clears up most incorrect rendering errors.  This does add quite a bit of additional processing resulting in a 18% performance hit when tested on my system.  Added an option to disable the retrace.  Which then renders the level without the portals present restoring performance.

Render errors:
![scrn0205](https://github.com/user-attachments/assets/02dd5875-6ed1-4d89-9c21-016cec635bde)
![scrn0206](https://github.com/user-attachments/assets/c4ffe312-83f6-4156-8ad7-246b32a8a84b)

Fixed:
![scrn0203](https://github.com/user-attachments/assets/22ef64e3-f3dd-44fc-9e2f-73b1c09a0a6d)
![scrn0204](https://github.com/user-attachments/assets/3d93488e-710d-4f68-930d-599cbc316f88)

Menu:
![scrn0212](https://github.com/user-attachments/assets/65b2bbfb-3ac1-431d-8994-b662acce07d4)

Also used new retrace functionality to correctly render end level tunnel so that mine is rendered through terrain, but only where the end level cube is.  Ie rays must pass through the end level cube to be visible otherwise render the terrain

Before
![scrn0222](https://github.com/user-attachments/assets/42da2748-bce8-4ad4-8f26-f197aa457334)

After
![scrn0221](https://github.com/user-attachments/assets/c4791d46-32a2-48fa-88d0-48e41ef4e755)
