### PR TITLE
Fix motion blur on external rendering

### DIFF
--- a/RT/RTgr.c
+++ b/RT/RTgr.c
@@ -1009,6 +1009,7 @@ void RT_DrawSubPolyModel(RT_ResourceHandle submodel, const RT_Mat4* const submod
 			.key = key,
 			.mesh_handle = submodel,
 			.transform = submodel_transform,
+			.prev_transform = submodel_transform,
 			.color = RT_PackRGBA(color),
 		};
 		RT_RaytraceMeshEx(&params);

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray_inline.hlsl
@@ -50,7 +50,8 @@ void PrimaryRayInline(COMPUTE_ARGS)
 	float2 screen_motion = prev_screen_p - screen_p;
 	screen_motion.y = -screen_motion.y;
 
-	geo.motion = screen_motion;
+	if (ray_payload.instance_idx != ~0)		// if ray hit nothing ignore screen motion
+		geo.motion = screen_motion;
 
 	// -------------------------------------------------------------------------------------
     // Write to G-buffers


### PR DESCRIPTION
When external rendering some objects did not get prev_transform set correctly, resulting in extreme motion blur.  Also affects background.  Updated to set prev_transform to the current transform and ignore screen motion for sky/ray misses.

Below is an example motion channel.  The mine exit and background are bright yellow which results in extreme motion blur being applied.
![scrn0356](https://github.com/user-attachments/assets/693d035e-02bf-45c9-8320-c2bb42b588dd)

Exit now has appropriate motion info and background is now black.
![scrn0359](https://github.com/user-attachments/assets/6727876f-4a13-42e0-a2c4-437bdbe0b10a)
